### PR TITLE
Fix lint errors

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -21,8 +21,9 @@ func NewBuildCmd() *cobra.Command {
 		Run:    runBuild,
 	}
 	cmd.Flags().BoolVar(&rootOpts.debug, "debug", false, "")
-	cmd.Flags().MarkHidden("debug")
-
+	if err := cmd.Flags().MarkHidden("debug"); err != nil {
+		logrus.Fatal(err)
+	}
 	return cmd
 }
 

--- a/pkg/asset/appliance/base_diskimage.go
+++ b/pkg/asset/appliance/base_diskimage.go
@@ -64,7 +64,9 @@ func (a *BaseDiskImage) Generate(dependencies asset.Parents) error {
 	if err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	log.StopSpinner(spinner, nil)
+	if err := log.StopSpinner(spinner, nil); err != nil {
+		return err
+	}
 
 	// Extracting gz file
 	spinner = log.NewSpinner(

--- a/pkg/asset/data/data_iso.go
+++ b/pkg/asset/data/data_iso.go
@@ -70,7 +70,9 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 	if err := a.copyRegistryImageIfNeeded(envConfig); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	log.StopSpinner(spinner, nil)
+	if err := log.StopSpinner(spinner, nil); err != nil {
+		return err
+	}
 
 	// Copying bootstrap images
 	spinner = log.NewSpinner(
@@ -88,7 +90,9 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 	if err := r.MirrorBootstrapImages(envConfig, applianceConfig); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	log.StopSpinner(spinner, nil)
+	if err := log.StopSpinner(spinner, nil); err != nil {
+		return err
+	}
 
 	// Copying release images
 	spinner = log.NewSpinner(
@@ -109,7 +113,9 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 	if err := releaseImageRegistry.StopRegistry(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	log.StopSpinner(spinner, nil)
+	if err := log.StopSpinner(spinner, nil); err != nil {
+		return err
+	}
 
 	spinner = log.NewSpinner(
 		"Generating data ISO...",

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -300,7 +300,7 @@ func (r *release) generateAdditionalImagesList(imagesMap map[string]bool) string
 	for imageURL := range imagesMap {
 		result.WriteString(fmt.Sprintf("    - name: \"%s\"", imageURL))
 		if i != len(r.additionalBootstrapImages) {
-			result.WriteString(fmt.Sprintf("\n"))
+			result.WriteString("\n")
 		}
 		i++
 	}


### PR DESCRIPTION
Fix the following issues:
* Error return value of ... is not checked
* unnecessary use of fmt.Sprintf