### PR TITLE
Add local registry to install ignition

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,8 +20,12 @@ func NewBuildCmd() *cobra.Command {
 		PreRun: preRunBuild,
 		Run:    runBuild,
 	}
-	cmd.Flags().BoolVar(&rootOpts.debug, "debug", false, "")
-	if err := cmd.Flags().MarkHidden("debug"); err != nil {
+	cmd.Flags().BoolVar(&rootOpts.debugBootstrap, "debug-bootstrap", false, "")
+	cmd.Flags().BoolVar(&rootOpts.debugInstall, "debug-install", false, "")
+	if err := cmd.Flags().MarkHidden("debug-bootstrap"); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := cmd.Flags().MarkHidden("debug-install"); err != nil {
 		logrus.Fatal(err)
 	}
 	return cmd
@@ -48,8 +52,9 @@ func runBuild(cmd *cobra.Command, args []string) {
 func preRunBuild(cmd *cobra.Command, args []string) {
 	// Generate EnvConfig asset
 	if err := getAssetStore().Fetch(&config.EnvConfig{
-		AssetsDir: rootOpts.dir,
-		Debug:     rootOpts.debug,
+		AssetsDir:      rootOpts.dir,
+		DebugBootstrap: rootOpts.debugBootstrap,
+		DebugInstall:   rootOpts.debugInstall,
 	}); err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -14,7 +14,8 @@ func NewGenerateInstallIgnitionCmd() *cobra.Command {
 		Hidden: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if err := getAssetStore().Fetch(&config.EnvConfig{
-				AssetsDir: rootOpts.dir,
+				AssetsDir:    rootOpts.dir,
+				DebugInstall: rootOpts.debugInstall,
 			}); err != nil {
 				logrus.Fatal(err)
 			}
@@ -34,6 +35,10 @@ func NewGenerateInstallIgnitionCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 		},
+	}
+	cmd.Flags().BoolVar(&rootOpts.debugInstall, "debug-install", false, "")
+	if err := cmd.Flags().MarkHidden("debug-install"); err != nil {
+		logrus.Fatal(err)
 	}
 
 	return cmd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,9 +11,10 @@ import (
 
 var (
 	rootOpts struct {
-		dir      string
-		logLevel string
-		debug    bool
+		dir            string
+		logLevel       string
+		debugBootstrap bool
+		debugInstall   bool
 	}
 )
 

--- a/data/scripts/bin/start-local-registry.sh.template
+++ b/data/scripts/bin/start-local-registry.sh.template
@@ -11,21 +11,20 @@ podman load -q -i /mnt/agentdata/images/{{.RegistryFilePath}}
 mkdir -p /tmp/certs
 openssl req -newkey rsa:4096 -nodes -sha256 -keyout /tmp/certs/domain.key \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN={{.RegistryDomain}}" \
-    -addext "subjectAltName=DNS:registry.appliance.com,DNS:quay.io" \
+    -addext "subjectAltName=DNS:{{.RegistryDomain}},DNS:quay.io" \
     -x509 -days 36500 -out /tmp/certs/domain.crt
 
 # Apply certificates
 mkdir -p /etc/docker/certs.d/{{.RegistryDomain}}:5000
 cp /tmp/certs/domain.crt /etc/docker/certs.d/{{.RegistryDomain}}:5000
 cp /tmp/certs/domain.crt /etc/pki/ca-trust/source/anchors/
-update-ca-trust
+update-ca-trust extract
 
 # Config registry dns
 # TODO: check if worth exposing only locally and/or support IPv6
 echo "0.0.0.0 {{.RegistryDomain}}" >> /etc/hosts
-echo "0.0.0.0 api-int.{{.RegistryDomain}}" >> /etc/hosts
 
-if [ {{.IsBootstrapStep}} ]; then
+if [ {{.IsBootstrapStep}} = true ]; then
   # Copy registry data to RAM
   registry_data=/tmp/registry
   cp -r {{.RegistryDataPath}} $registry_data
@@ -38,7 +37,7 @@ fi
 # Run local registry image
 podman rm registry --force
 podman run --privileged -d --name registry \
-    -p 5000:5000 -p 443:5000 \
+    -p 5000:5000 -p 5443:5000 \
     -v $registry_data:/var/lib/registry --restart=always \
     -v /tmp/certs:/certs \
     -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \

--- a/hack/diskimage/test_install_ignition.md
+++ b/hack/diskimage/test_install_ignition.md
@@ -1,7 +1,7 @@
 # Test changes in InstallIgnition asset
 
 ## Preparation steps:    
-1. Build appliance with --debug flag
+1. Build appliance with --debug-bootstrap flag
 2. Boot appliance and wait for "Ironic will reboot the node shortly" in assisted-service logs.
    - Leaves the appliance in pre-installed state (bootstrap completed)
 3. Shutdown appliance
@@ -13,6 +13,7 @@
 1. Run 'generate-install-ignition' command
    - Generates merged ignition (base ignition from step 4 + InstallIgnition asset)
    - Outputs to assets/ignition/install/config.ign
+   - use --debug-install flag to include the public sshKey from appliance-config
 2. Run hack/diskimage/embed_install_ignition.sh
    - Creates a snapshot and embeds the merged ignition
 3. Run the appliance

--- a/pkg/asset/config/env_config.go
+++ b/pkg/asset/config/env_config.go
@@ -18,7 +18,8 @@ type EnvConfig struct {
 	CacheDir  string
 	TempDir   string
 
-	Debug bool
+	DebugBootstrap bool
+	DebugInstall   bool
 }
 
 var _ asset.Asset = (*EnvConfig)(nil)

--- a/pkg/asset/ignition/bootstrap_ignition.go
+++ b/pkg/asset/ignition/bootstrap_ignition.go
@@ -83,7 +83,7 @@ func (i *BootstrapIgnition) Generate(dependencies asset.Parents) error {
 		},
 	}
 
-	if envConfig.Debug {
+	if envConfig.DebugBootstrap {
 		// Avoid machine reboot after bootstrap to debug install ignition
 		bootstrapServices = append(bootstrapServices, "ironic-agent.service")
 	}

--- a/pkg/asset/registry/registriesconf.go
+++ b/pkg/asset/registry/registriesconf.go
@@ -61,6 +61,7 @@ func (i *RegistriesConf) Generate(dependencies asset.Parents) error {
 					},
 				},
 			},
+			// TODO: remove once not using custom AGENT_DOCKER_IMAGE from quay.io
 			{
 				Endpoint: sysregistriesv2.Endpoint{
 					Location: "quay.io",

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -107,21 +107,40 @@ func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, regist
 	osImages, _ := json.Marshal(osImageArr)
 
 	return struct {
-		IsBootstrapStep                                                   bool
-		InstallIgnitionConfig                                             string
+		IsBootstrapStep       bool
+		InstallIgnitionConfig string
+
 		ReleaseImages, ReleaseImage, OsImages                             string
 		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage string
 	}{
 		IsBootstrapStep:       true,
 		InstallIgnitionConfig: installIgnitionConfig,
 
+		// Images
+		ReleaseImages: string(releaseImages),
+		ReleaseImage:  swag.StringValue(ocpReleaseImage.URL),
+		OsImages:      string(osImages),
+
 		// Registry
-		ReleaseImages:    string(releaseImages),
-		ReleaseImage:     *ocpReleaseImage.URL,
 		RegistryDataPath: registryDataPath,
 		RegistryDomain:   registry.RegistryDomain,
 		RegistryFilePath: RegistryFilePath,
 		RegistryImage:    RegistryImage,
-		OsImages:         string(osImages),
+	}
+}
+
+func GetInstallIgnitionTemplateData(registryDataPath string) interface{} {
+	return struct {
+		IsBootstrapStep bool
+
+		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage string
+	}{
+		IsBootstrapStep: false,
+
+		// Registry
+		RegistryDataPath: registryDataPath,
+		RegistryDomain:   registry.RegistryDomain,
+		RegistryFilePath: RegistryFilePath,
+		RegistryImage:    RegistryImage,
 	}
 }


### PR DESCRIPTION
As part of the services in install ignition, we need to start a local registry for serving the entire release payload.

In addition, for debugging the process we need two debug flags:
* --debug-bootstrap: stops the flow after bootstrap so install step could be easily tested.
* --debug-install: adds ssh public key to install ignition for connecting during installation.