### PR TITLE
MGMT-14677: Bump to go 1.19

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -1,5 +1,5 @@
 # Build appliance
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/Dockerfile.openshift-appliance-build
+++ b/Dockerfile.openshift-appliance-build
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/appliance
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
handle: atomic.Pointer  module requires Go 1.19