### PR TITLE
Removed usages of deprecated io/ioutil

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -3,14 +3,13 @@ package fileutil
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
 func CopyFile(source, dest string) error {
 	// Read source file
-	bytesRead, err := ioutil.ReadFile(source)
+	bytesRead, err := os.ReadFile(source)
 	if err != nil {
 		return err
 	}
@@ -27,7 +26,7 @@ func CopyFile(source, dest string) error {
 	}
 
 	// Copy file to dest
-	if err = ioutil.WriteFile(dest, bytesRead, fileinfo.Mode().Perm()); err != nil {
+	if err = os.WriteFile(dest, bytesRead, fileinfo.Mode().Perm()); err != nil {
 		return err
 	}
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -3,7 +3,6 @@ package release
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -191,7 +190,7 @@ func (r *release) mirrorImages(envConfig *config.EnvConfig, applianceConfig *con
 		return err
 	}
 
-	tempDir, err := ioutil.TempDir(envConfig.TempDir, "oc-mirror")
+	tempDir, err := os.MkdirTemp(envConfig.TempDir, "oc-mirror")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.