### PR TITLE
Update golangci-lint version and timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build-openshift-ci-test-bin:
 	./hack/setup_env.sh
 
 lint:
-	golangci-lint run -v
+	golangci-lint run -v --timeout=5m
 
 test: $(REPORTS)
 	go test -count=1 -cover -coverprofile=$(COVER_PROFILE) ./...

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 yum install -y install podman genisoimage && yum clean all
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
 GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
The version of `golangci-lint` that we are currently using is three years old. This patch updates it to the latest available version.

In addition the default timeout is one minute, and that isn't enough when it runs without a cache (which is always the case in the CI jobs):

```
$ golangci-lint cache clean
$ make lint
...
ERRO Running error: context loading failed: failed to load packages: timed out to load packages: context deadline exceeded
ERRO Timeout exceeded: try increasing it by passing --timeout option
```

Increasing the timeout to five minutes allows the execution to finish, and it takes approximately two minutes:

```
$ golangci-lint cache clean
$ golangci-lint run -v --timeout=5m
...
INFO Execution took 1m47.572011137s
```

This patch increases the timeout to five minutes.