### PR TITLE
MGMT-14865: Added userCorePass to ApplianceConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A configuration file named `appliance-config.yaml` is required for running the t
 * diskSizeGB: Virtual size of the appliance disk image
 * pullSecret: PullSecret required for mirroring the OCP release payload
 * sshKey: Public SSH key for accessing the appliance
+* userCorePass: Password for user 'core' to login from console
 
 ##### Generate config file template
 
@@ -83,7 +84,7 @@ ocpRelease:
 diskSizeGB: 200
 pullSecret: ...
 sshKey: ...
-
+userCorePass: ...
 ```
 
 #### Start appliance disk image build flow

--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -83,6 +83,9 @@ pullSecret: pull-secret
 # Public SSH key for accessing the appliance
 # [Optional]
 sshKey: ssh-key
+# Password of user 'core' for connecting from console
+# [Optional]
+userCorePass: user-core-pass
 `
 	a.Template = applianceConfigTemplate
 

--- a/pkg/types/appliance_config_type.go
+++ b/pkg/types/appliance_config_type.go
@@ -11,10 +11,11 @@ type ApplianceConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	OcpRelease ReleaseImage `json:"ocpRelease"`
-	DiskSizeGB int          `json:"diskSizeGb"`
-	PullSecret string       `json:"pullSecret"`
-	SshKey     *string      `json:"sshKey"`
+	OcpRelease   ReleaseImage `json:"ocpRelease"`
+	DiskSizeGB   int          `json:"diskSizeGb"`
+	PullSecret   string       `json:"pullSecret"`
+	SshKey       *string      `json:"sshKey"`
+	UserCorePass *string      `json:"userCorePass"`
 }
 
 type ReleaseImage struct {


### PR DESCRIPTION
Added support for specifying user 'core' password on ApplianceConfig. This is required to login from console.