### PR TITLE
Adding go to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ of an OpenShift cluster. Thus, all required images are included in the appliance
 * oc
 * skopeo
 * podman
+* go >= 1.19
 
 Note: for oc-mirror usage, the builder ensures that the pull secret exists at `~/.docker/config.json`
 


### PR DESCRIPTION
We need to ensure golan version 1.19 or above is installed prior to running make build-appliance.
Otherwise the following error is thrown:
note: module requires Go 1.19
make: *** [Makefile:19: build-appliance] Error 2