### PR TITLE
MGMT-14917: Fix rhcos grub menu item removal

### DIFF
--- a/pkg/templates/scripts/guestfish/guestfish.sh.template
+++ b/pkg/templates/scripts/guestfish/guestfish.sh.template
@@ -45,4 +45,4 @@ part-set-gpt-type /dev/sda 5 {{.ReservedPartitionGUID}}
 # Handle GRUB
 mount /dev/sda3 /
 copy-in {{.CfgFile}} /grub2
-rm-f /boot/loader/entries/ostree-1-fedora-coreos.conf
+rm-f /boot/loader/entries/ostree-1-rhcos.conf


### PR DESCRIPTION
The base disk image is rhcos now (instead of fedora), hence the entry item is on ostree-1-rhcos.conf.