### PR TITLE
MGMT-14872: generate openshift-install download URL

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/openshift/appliance/pkg/asset/appliance"
 	"github.com/openshift/appliance/pkg/asset/config"
+	"github.com/openshift/appliance/pkg/asset/installer"
 	"github.com/openshift/appliance/pkg/log"
-	"github.com/openshift/appliance/pkg/templates"
 	"github.com/openshift/installer/pkg/asset"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	"github.com/openshift/installer/pkg/metrics/timer"
@@ -47,10 +47,20 @@ func runBuild(cmd *cobra.Command, args []string) {
 		logrus.Fatal(errors.Wrapf(err, "failed to fetch %s", applianceDiskImage.Name()))
 	}
 
+	// Generate openshift-install binary download URL
+	installerBinary := installer.InstallerBinary{}
+	if err := getAssetStore().Fetch(&installerBinary); err != nil {
+		logrus.Fatal(errors.Wrapf(err, "failed to fetch %s", installerBinary.Name()))
+	}
+
 	timer.StopTimer(timer.TotalTimeElapsed)
 	timer.LogSummary()
 
-	logrus.Infof("Appliance successfully created at assets directory: %s", templates.ApplianceFileName)
+	logrus.Info()
+	logrus.Infof("Appliance successfully created at assets directory: %s", applianceDiskImage.File.Filename)
+	logrus.Info()
+	logrus.Infof("Create configuration ISO using: openshift-install agent create config-image")
+	logrus.Infof("Download openshift-install from: %s", installerBinary.URL)
 }
 
 func preRunBuild(cmd *cobra.Command, args []string) {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.0
 	github.com/thoas/go-funk v0.9.3
+	github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a
 	golang.org/x/term v0.8.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.27.2
@@ -40,7 +41,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/go-version v1.6.0
 	github.com/jongio/azidext/go/azidext v0.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/microsoft/kiota-abstractions-go v0.14.0 // indirect
@@ -202,7 +203,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/thedevsaddam/retry v1.2.1
-	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/crypto v0.1.0
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1181,6 +1181,8 @@ github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vmw-guestinfo v0.0.0-20220317130741-510905f0efa3/go.mod h1:CSBTxrhePCm0cmXNKDGeu+6bOQzpaEklfCqEpn89JWk=
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
+github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a h1:6cKSHLRphD9Fo1LJlISiulvgYCIafJ3QfKLimPYcAGc=
+github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a/go.mod h1:nccQrXCnc5SjsThFLmL7hYbtT/mHJcuolPifzY5vJqE=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=

--- a/pkg/asset/ignition/recovery_ignition.go
+++ b/pkg/asset/ignition/recovery_ignition.go
@@ -49,7 +49,7 @@ func (i *RecoveryIgnition) Generate(dependencies asset.Parents) error {
 		return err
 	}
 
-	inst := installer.NewInstaller(envConfig)
+	inst := installer.NewInstaller(envConfig, applianceConfig)
 	unconfiguredIgnitionFileName, err := inst.CreateUnconfiguredIgnition(
 		swag.StringValue(applianceConfig.Config.OcpRelease.URL),
 		applianceConfig.Config.PullSecret,

--- a/pkg/asset/installer/installer_binary.go
+++ b/pkg/asset/installer/installer_binary.go
@@ -1,0 +1,41 @@
+package installer
+
+import (
+	"github.com/openshift/appliance/pkg/asset/config"
+	"github.com/openshift/appliance/pkg/installer"
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/pkg/errors"
+)
+
+type InstallerBinary struct {
+	URL string
+}
+
+var _ asset.Asset = (*InstallerBinary)(nil)
+
+func (a *InstallerBinary) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&config.EnvConfig{},
+		&config.ApplianceConfig{},
+	}
+}
+
+func (a *InstallerBinary) Generate(dependencies asset.Parents) error {
+	envConfig := &config.EnvConfig{}
+	applianceConfig := &config.ApplianceConfig{}
+	dependencies.Get(envConfig, applianceConfig)
+
+	inst := installer.NewInstaller(envConfig, applianceConfig)
+	installerDownloadURL, err := inst.GetInstallerDownloadURL()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to generate installer download URL")
+	}
+	a.URL = installerDownloadURL
+
+	return nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *InstallerBinary) Name() string {
+	return "Installer Binary"
+}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -5,34 +5,44 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/cavaliergopher/grab/v3"
+	"github.com/hashicorp/go-version"
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/executer"
-	"github.com/openshift/appliance/pkg/release"
+	"github.com/openshift/appliance/pkg/log"
 	"github.com/sirupsen/logrus"
+	"github.com/walle/targz"
 )
 
 const (
-	templateUnconfiguredIgnitionImage  = "podman run %s agent create unconfigured-ignition --dir %s"
-	templateUnconfiguredIgnitionBinary = "%s/openshift-install agent create unconfigured-ignition --dir %s"
-	installerImageName                 = "installer"
+	installerBinaryName                = "openshift-install"
+	installerBinaryGZ                  = "openshift-install-linux.tar.gz"
+	templateUnconfiguredIgnitionBinary = "%s agent create unconfigured-ignition --dir %s"
+	templateInstallerDownloadURL       = "https://mirror.openshift.com/pub/openshift-v%s/%s/clients/ocp/%s/openshift-install-linux.tar.gz"
 	unconfiguredIgnitionFileName       = "unconfigured-agent.ign"
 )
 
 type Installer interface {
 	CreateUnconfiguredIgnition(releaseImage, pullSecret string) (string, error)
+	GetInstallerDownloadURL() (string, error)
 }
 
 type installer struct {
-	EnvConfig *config.EnvConfig
+	EnvConfig       *config.EnvConfig
+	ApplianceConfig *config.ApplianceConfig
 }
 
-func NewInstaller(envConfig *config.EnvConfig) Installer {
+func NewInstaller(envConfig *config.EnvConfig, applianceConfig *config.ApplianceConfig) Installer {
 	return &installer{
-		EnvConfig: envConfig,
+		EnvConfig:       envConfig,
+		ApplianceConfig: applianceConfig,
 	}
 }
 
 func (i *installer) CreateUnconfiguredIgnition(releaseImage, pullSecret string) (string, error) {
+	var openshiftInstallFilePath string
+	var err error
+
 	if !i.EnvConfig.DebugBaseIgnition {
 		// TODO: remove once the API is ready (see below)
 		if true {
@@ -41,21 +51,58 @@ func (i *installer) CreateUnconfiguredIgnition(releaseImage, pullSecret string) 
 
 		// TODO: use logic below once the API is ready ('agent create unconfigured-ignition')
 		//       see: https://issues.redhat.com/browse/AGENT-574
-		r := release.NewRelease(releaseImage, pullSecret, i.EnvConfig)
-		imageUri, err := r.GetImageFromRelease(installerImageName)
-		if err != nil {
-			return "", err
+		if fileName := i.EnvConfig.FindInCache(installerBinaryName); fileName != "" {
+			logrus.Info("Reusing openshift-install binary from cache")
+			openshiftInstallFilePath = fileName
+		} else {
+			openshiftInstallFilePath, err = i.downloadInstallerBinary()
+			if err != nil {
+				return "", err
+			}
 		}
-		createCmd := fmt.Sprintf(templateUnconfiguredIgnitionImage, imageUri, i.EnvConfig.TempDir)
-		args := strings.Split(createCmd, " ")
-		_, err = executer.NewExecuter().Execute(args[0], args[1:]...)
-		return filepath.Join(i.EnvConfig.TempDir, unconfiguredIgnitionFileName), err
 	} else {
 		logrus.Debugf("Using openshift-install binary from cache dir to fetch unconfigured-ignition")
-		cacheDir := filepath.Join(i.EnvConfig.AssetsDir, config.CacheDir)
-		createCmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, cacheDir, i.EnvConfig.TempDir)
-		args := strings.Split(createCmd, " ")
-		_, err := executer.NewExecuter().Execute(args[0], args[1:]...)
-		return filepath.Join(i.EnvConfig.TempDir, unconfiguredIgnitionFileName), err
+		openshiftInstallFilePath = filepath.Join(i.EnvConfig.AssetsDir, config.CacheDir, installerBinaryName)
 	}
+
+	createCmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, openshiftInstallFilePath, i.EnvConfig.TempDir)
+	args := strings.Split(createCmd, " ")
+	_, err = executer.NewExecuter().Execute(args[0], args[1:]...)
+	return filepath.Join(i.EnvConfig.TempDir, unconfiguredIgnitionFileName), err
+}
+
+func (i *installer) GetInstallerDownloadURL() (string, error) {
+	releaseVersion, err := version.NewVersion(i.ApplianceConfig.Config.OcpRelease.Version)
+	if err != nil {
+		return "", err
+	}
+	majorVersion := fmt.Sprint(releaseVersion.Segments()[0])
+	cpuArch := i.ApplianceConfig.GetCpuArchitecture()
+
+	return fmt.Sprintf(templateInstallerDownloadURL, majorVersion, cpuArch, releaseVersion), nil
+}
+
+func (i *installer) downloadInstallerBinary() (string, error) {
+	spinner := log.NewSpinner(
+		"Fetching openshift-install binary...",
+		"Successfully fetched openshift-install binary",
+		"Failed to fetch openshift-install binary",
+		i.EnvConfig,
+	)
+
+	logrus.Debugf("Fetch openshift-install binary from mirror.openshift.com")
+	installerDownloadURL, err := i.GetInstallerDownloadURL()
+	if err != nil {
+		return "", log.StopSpinner(spinner, err)
+	}
+	compressed := filepath.Join(i.EnvConfig.TempDir, installerBinaryGZ)
+	_, err = grab.Get(compressed, installerDownloadURL)
+	if err != nil {
+		return "", log.StopSpinner(spinner, err)
+	}
+	if err = targz.Extract(compressed, i.EnvConfig.CacheDir); err != nil {
+		return "", log.StopSpinner(spinner, err)
+	}
+	log.StopSpinner(spinner, nil)
+	return filepath.Join(i.EnvConfig.CacheDir, installerBinaryName), nil
 }


### PR DESCRIPTION
As a last step of the build, generate and output a download URL for openshift-install binary
 This is required for using the upcoming config-image API.