### PR TITLE
MGMT-14971: Change assisted installer agent image to use master

### DIFF
--- a/data/scripts/bin/get-container-images.sh.template
+++ b/data/scripts/bin/get-container-images.sh.template
@@ -12,5 +12,5 @@ cat <<EOF >/usr/local/share/assisted-service/agent-images.env
 SERVICE_IMAGE=$(image_for agent-installer-api-server)
 INSTALLER_IMAGE=$(image_for agent-installer-orchestrator)
 CONTROLLER_IMAGE=$(image_for agent-installer-csr-approver)
-AGENT_DOCKER_IMAGE=quay.io/masayag/assisted-installer-agent:billi
+AGENT_DOCKER_IMAGE=quay.io/edge-infrastructure/assisted-installer-agent:latest
 EOF

--- a/pkg/templates/consts.go
+++ b/pkg/templates/consts.go
@@ -36,5 +36,5 @@ const (
 
 	// AI images
 	// TODO: remove when official images are updates
-	AssistedInstallerAgentImage = "quay.io/masayag/assisted-installer-agent:billi"
+	AssistedInstallerAgentImage = "quay.io/edge-infrastructure/assisted-installer-agent:latest"
 )


### PR DESCRIPTION
Per https://github.com/openshift/assisted-installer-agent/pull/554, the changes needed by the appliance flow are in the master branch. So we should stop using a temporary image as a workaround.