### PR TITLE
MGMT-15053: fallback to stable release channel

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -262,6 +262,8 @@ func (a *ApplianceConfig) validateOcpRelease() field.ErrorList {
 				a.Config.OcpRelease.Channel,
 				"Unsupported OCP release channel (supported channels: stable|fast|eus|candidate)")}...)
 		}
+	} else {
+		a.Config.OcpRelease.Channel = swag.String(string(graph.ReleaseChannelStable))
 	}
 
 	// Validate ocpRelease.cpuArchitecture


### PR DESCRIPTION
If ocpRelease.Channel is missing in ApplianceConfig, its value should default to 'stable'.