### PR TITLE
Custom openshift-install on assets dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ export KUBECONFIG=/etc/kubernetes/bootstrap-secrets/kubeconfig
 #### unconfigured-ignition API
 
 Add `--debug-base-ignition` flag to the build command for using a custom openshift-install binary to invoke `agent create unconfigured-ignition`.
-Use these [instructions](https://github.com/openshift/installer#quick-start) to build the openshift-install binary, and copy it into `cache` dir under `assets`.
+Use these [instructions](https://github.com/openshift/installer#quick-start) to build the openshift-install binary, and copy it into `assets` dir.
 
 #### Test changes in the install ignition
 

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -61,8 +61,8 @@ func (i *installer) CreateUnconfiguredIgnition(releaseImage, pullSecret string) 
 			}
 		}
 	} else {
-		logrus.Debugf("Using openshift-install binary from cache dir to fetch unconfigured-ignition")
-		openshiftInstallFilePath = filepath.Join(i.EnvConfig.AssetsDir, config.CacheDir, installerBinaryName)
+		logrus.Debugf("Using openshift-install binary from assets dir to fetch unconfigured-ignition")
+		openshiftInstallFilePath = filepath.Join(i.EnvConfig.AssetsDir, installerBinaryName)
 	}
 
 	createCmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, openshiftInstallFilePath, i.EnvConfig.TempDir)


### PR DESCRIPTION
Search for custom openshift-install binary on assets dir when using the `debug-base-ignition` flag.
This is useful for dev-scripts as the custom binary is copied to the assets dir.