### PR TITLE
fix registry uri validation

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -41,7 +41,7 @@ const (
 	RegistryMaxPort = 65535
 
 	// Validation commands
-	PodmanInspect = "podman inspect %s"
+	PodmanPull = "podman pull %s"
 )
 
 var (
@@ -262,7 +262,7 @@ func (a *ApplianceConfig) validateImageRegistry() field.ErrorList {
 	}
 
 	if a.Config.ImageRegistry.URI != nil {
-		cmd := fmt.Sprintf(PodmanInspect, swag.StringValue(a.Config.ImageRegistry.URI))
+		cmd := fmt.Sprintf(PodmanPull, swag.StringValue(a.Config.ImageRegistry.URI))
 		logrus.Debugf("Running uri validation cmd: %s", cmd)
 		args := strings.Split(cmd, " ")
 		if _, err := a.executer.Execute(args[0], args[1:]...); err != nil {


### PR DESCRIPTION
'podman inspect' doesn't work if the image isn't pulled yet. Hence, change validation to 'podman pull' instead.