### PR TITLE
MGMT-15189: remove debug-install flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,6 @@ make lint
 
 Add `--debug-bootstrap` flag to the build command to avoid machine reboot on bootstrap step completion. Useful for taking a snapshot of the appliance disk image before testing changes in the install ignition. 
 
-#### Install step
-
-Add `--debug-install` flag to the build command for enabling ssh login on the installation step.
-The public ssh key provided in appliance-config.yaml is used (`sshKey` property).
-During installation, to run `oc` commands, define `KUBECONFIG` using:
-```bash
-export KUBECONFIG=/etc/kubernetes/bootstrap-secrets/kubeconfig
-```
-
 #### unconfigured-ignition API
 
 Add `--debug-base-ignition` flag to the build command for using a custom openshift-install binary to invoke `agent create unconfigured-ignition`.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -21,12 +21,8 @@ func NewBuildCmd() *cobra.Command {
 		Run:    runBuild,
 	}
 	cmd.Flags().BoolVar(&rootOpts.debugBootstrap, "debug-bootstrap", false, "")
-	cmd.Flags().BoolVar(&rootOpts.debugInstall, "debug-install", false, "")
 	cmd.Flags().BoolVar(&rootOpts.debugBaseIgnition, "debug-base-ignition", false, "")
 	if err := cmd.Flags().MarkHidden("debug-bootstrap"); err != nil {
-		logrus.Fatal(err)
-	}
-	if err := cmd.Flags().MarkHidden("debug-install"); err != nil {
 		logrus.Fatal(err)
 	}
 	if err := cmd.Flags().MarkHidden("debug-base-ignition"); err != nil {
@@ -77,7 +73,6 @@ func preRunBuild(cmd *cobra.Command, args []string) {
 	if err := getAssetStore().Fetch(&config.EnvConfig{
 		AssetsDir:         rootOpts.dir,
 		DebugBootstrap:    rootOpts.debugBootstrap,
-		DebugInstall:      rootOpts.debugInstall,
 		DebugBaseIgnition: rootOpts.debugBaseIgnition,
 	}); err != nil {
 		logrus.Fatal(err)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -15,7 +15,6 @@ func NewGenerateInstallIgnitionCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if err := getAssetStore().Fetch(&config.EnvConfig{
 				AssetsDir:    rootOpts.dir,
-				DebugInstall: rootOpts.debugInstall,
 			}); err != nil {
 				logrus.Fatal(err)
 			}
@@ -35,10 +34,6 @@ func NewGenerateInstallIgnitionCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 		},
-	}
-	cmd.Flags().BoolVar(&rootOpts.debugInstall, "debug-install", false, "")
-	if err := cmd.Flags().MarkHidden("debug-install"); err != nil {
-		logrus.Fatal(err)
 	}
 
 	return cmd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,6 @@ var (
 		dir               string
 		logLevel          string
 		debugBootstrap    bool
-		debugInstall      bool
 		debugBaseIgnition bool
 	}
 )

--- a/hack/diskimage/test_install_ignition.md
+++ b/hack/diskimage/test_install_ignition.md
@@ -13,7 +13,6 @@
 1. Run 'generate-install-ignition' command
    - Generates merged ignition (base ignition from step 4 + InstallIgnition asset)
    - Outputs to assets/ignition/install/config.ign
-   - use --debug-install flag to include the public sshKey from appliance-config
 2. Run hack/diskimage/embed_install_ignition.sh
    - Creates a snapshot and embeds the merged ignition
 3. Run the appliance

--- a/pkg/asset/config/env_config.go
+++ b/pkg/asset/config/env_config.go
@@ -21,7 +21,6 @@ type EnvConfig struct {
 	TempDir   string
 
 	DebugBootstrap    bool
-	DebugInstall      bool
 	DebugBaseIgnition bool
 }
 


### PR DESCRIPTION
The --debug-install flag is now redundant since a public ssh key can now be specified in the config-image (as part of install-config.yaml).