### PR TITLE
Remove redundant install from setup_env script

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-yum install -y install podman genisoimage && yum clean all
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.52.2
 GOFLAGS='' go install golang.org/x/tools/cmd/goimports@v0.1.5
 GOFLAGS='' go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
We don't need to install podman and genisoimage as part of openshift-appliance-build.
For now it'll be used only for running unit-tests/coverage.