### PR TITLE
MGMT-15235: Compile with CGO_ENABLED=1 for FIPS

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -4,7 +4,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 COPY . .
-RUN cd cmd && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/openshift-appliance
+RUN cd cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/openshift-appliance
 
 # Create final image
 FROM quay.io/centos/centos:stream8

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 
 build-appliance:
 	mkdir -p build
-	cd ./cmd && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o ../build/openshift-appliance
+	cd ./cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o ../build/openshift-appliance
 
 build-openshift-ci-test-bin:
 	./hack/setup_env.sh


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
In order to be FIPS compliant, we need to compile
all go code with CGO_ENABLED=1.

/cc @nmagnezi @filanov 