### PR TITLE
Remove GO111MODULE

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -4,7 +4,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 COPY . .
-RUN cd cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/openshift-appliance
+RUN cd cmd && CGO_ENABLED=1 GOFLAGS="" go build -o /build/openshift-appliance
 
 # Create final image
 FROM quay.io/centos/centos:stream8

--- a/Dockerfile.openshift-appliance-build
+++ b/Dockerfile.openshift-appliance-build
@@ -1,5 +1,4 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.19
-ENV GO111MODULE=on
 ENV GOFLAGS=""
 
 COPY hack/setup_env.sh ./

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 
 build-appliance:
 	mkdir -p build
-	cd ./cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o ../build/openshift-appliance
+	cd ./cmd && CGO_ENABLED=1 GOFLAGS="" go build -o ../build/openshift-appliance
 
 build-openshift-ci-test-bin:
 	./hack/setup_env.sh


### PR DESCRIPTION
The `GO111MODULE=on` setting is the default since Go 1.16 so we can remove it and simplify the build commands.

Related: https://github.com/golang/go/issues/41330