### PR TITLE
Add support for env vars in executer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/cobra v1.6.0
 	github.com/thoas/go-funk v0.9.3
 	github.com/walle/targz v0.0.0-20140417120357-57fe4206da5a
+	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb
 	golang.org/x/term v0.8.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -1299,6 +1299,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb h1:xIApU0ow1zwMa2uL1VDNeQlNVFTWMQxZUZCMDy0Q4Us=
+golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/asset/appliance/appliance_diskimage.go
+++ b/pkg/asset/appliance/appliance_diskimage.go
@@ -81,7 +81,10 @@ func (a *ApplianceDiskImage) Generate(dependencies asset.Parents) error {
 	logrus.Debug("Running guestfish script")
 	guestfishFileName := templates.GetFilePathByTemplate(
 		consts.GuestfishScriptTemplateFile, envConfig.TempDir)
-	if _, err := executer.NewExecuter().Execute(guestfishFileName); err != nil {
+	_, err := executer.NewExecuter().Execute(executer.Command{
+		Args: []string{guestfishFileName},
+	})
+	if err != nil {
 		return log.StopSpinner(spinner, errors.Wrapf(err, "guestfish script failure"))
 	}
 

--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -265,8 +265,10 @@ func (a *ApplianceConfig) validateImageRegistry() field.ErrorList {
 	if a.Config.ImageRegistry.URI != nil {
 		cmd := fmt.Sprintf(PodmanPull, swag.StringValue(a.Config.ImageRegistry.URI))
 		logrus.Debugf("Running uri validation cmd: %s", cmd)
-		args := strings.Split(cmd, " ")
-		if _, err := executer.NewExecuter().Execute(args[0], args[1:]...); err != nil {
+		_, err := executer.NewExecuter().Execute(executer.Command{
+			Args: strings.Fields(cmd),
+		})
+		if err != nil {
 			allErrs = append(allErrs, field.ErrorList{field.Invalid(field.NewPath("imageRegistry.uri"),
 				swag.StringValue(a.Config.ImageRegistry.URI),
 				fmt.Sprintf("Invalid uri: %s", err.Error()))}...)

--- a/pkg/coreos/coreos.go
+++ b/pkg/coreos/coreos.go
@@ -93,8 +93,9 @@ func (c *coreos) EmbedIgnition(ignition []byte, isoPath string) error {
 
 	// Invoke embed ignition command
 	embedCmd := fmt.Sprintf(templateEmbedIgnition, ignitionFile.Name(), isoPath)
-	args := strings.Split(embedCmd, " ")
-	_, err = executer.NewExecuter().Execute(args[0], args[1:]...)
+	_, err = executer.NewExecuter().Execute(executer.Command{
+		Args: strings.Fields(embedCmd),
+	})
 	return err
 }
 

--- a/pkg/executer/executer.go
+++ b/pkg/executer/executer.go
@@ -2,16 +2,31 @@ package executer
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
+
+// Command contains the description of a command to be executed by an executor.
+type Command struct {
+	// Env is a set of additional environment variables. The keys of the map are the names of
+	// the variables, and the values of the map their values. If the value of a variable is nil
+	// then it will be removed from the environment. Otherwise it will converted to a string and
+	// added to the environment, replacing any previous value.
+	Env map[string]any
+
+	// Args are the command line arguments.
+	Args []string
+}
 
 //go:generate mockgen -source=executer.go -package=executer -destination=mock_executer.go
 type Executer interface {
-	Execute(command string, args ...string) (string, error)
+	Execute(command Command) (string, error)
 	TempFile(dir, pattern string) (f *os.File, err error)
 }
 
@@ -22,17 +37,90 @@ func NewExecuter() Executer {
 	return &executer{}
 }
 
-func (e *executer) Execute(command string, args ...string) (string, error) {
-	var stdoutBytes, stderrBytes bytes.Buffer
-	cmd := exec.Command(command, args...)
-	cmd.Stdout = &stdoutBytes
-	cmd.Stderr = &stderrBytes
-	err := cmd.Run()
-	if err != nil {
-		return "", errors.Wrapf(err, "Failed to execute cmd (%s): %s", cmd, stderrBytes.String())
+func (e *executer) Execute(command Command) (result string, err error) {
+	if len(command.Args) < 1 {
+		err = errors.New("at least one command line argument is required")
+		return
 	}
+	bin := command.Args[0]
+	args := command.Args[1:]
+	cmd := exec.Command(bin, args...)
+	if command.Env != nil {
+		cmd.Env = e.mergeEnv(os.Environ(), command.Env)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err = cmd.Run()
+	if err != nil {
+		err = errors.Wrapf(err, "failed to execute cmd (%s): %s", bin, stderr.String())
+		return
+	}
+	result = strings.TrimSuffix(stdout.String(), "\n")
+	return
+}
 
-	return strings.TrimSuffix(stdoutBytes.String(), "\n"), nil
+// mergeEnv merges the given environment with the given variables. The environment is expected to be
+// a list of strings in the the same format used by the os.Environ function. The variables is a map
+// describing the changes to make to that environment. The keys of the map are the names of the
+// variables and the values of the map the values. Variables with value nil will be removed from the
+// environment. The rest will be added, replacing any previous value.
+func (e *executer) mergeEnv(env []string, vars map[string]any) []string {
+	values := e.parseEnv(env)
+	for name, value := range vars {
+		if value == nil {
+			delete(values, name)
+		} else {
+			values[name] = fmt.Sprintf("%s", value)
+		}
+	}
+	return e.renderEnv(values)
+}
+
+// parseEnv takes a set of environment variables in the format used by os.Environ and puts them in a
+// map where the keys of the map are the names of the variables and the values of the map the values
+// of the variables.
+func (e *executer) parseEnv(env []string) map[string]string {
+	values := map[string]string{}
+	for _, pair := range env {
+		name, value := e.parseVar(pair)
+		values[name] = value
+	}
+	return values
+}
+
+// parseVar parses splits a name value pair into its name and value, using the equals sign as
+// separator. If there is no equal sign in the input the output will be the name of the variable and
+// an empty string as value.
+func (e *executer) parseVar(pair string) (name, value string) {
+	index := strings.Index(pair, "=")
+	if index != -1 {
+		name = pair[0:index]
+		value = pair[index+1:]
+	} else {
+		name = pair
+		value = ""
+	}
+	return
+}
+
+// renderEnv converts a map containing name value pairs into a slice of strings with the same format
+// used by os.Environ.
+func (e *executer) renderEnv(values map[string]string) []string {
+	names := maps.Keys(values)
+	slices.Sort(names)
+	env := make([]string, len(names))
+	for i, name := range names {
+		value := values[name]
+		env[i] = e.renderVar(name, value)
+	}
+	return env
+}
+
+// renderVar renders an environment variable using the equals sign to separate the name from the value.
+func (e *executer) renderVar(name, value string) string {
+	return fmt.Sprintf("%s=%s", name, value)
 }
 
 func (e *executer) TempFile(dir, pattern string) (f *os.File, err error) {

--- a/pkg/executer/executer_test.go
+++ b/pkg/executer/executer_test.go
@@ -1,0 +1,121 @@
+package executer
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Executer", func() {
+	var (
+		executer Executer
+	)
+
+	BeforeEach(func() {
+		executer = NewExecuter()
+	})
+
+	It("Fails if command line args are nil", func() {
+		result, err := executer.Execute(Command{
+			Args: nil,
+		})
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("argument"))
+		Expect(msg).To(ContainSubstring("required"))
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Fails if command line args are empty", func() {
+		result, err := executer.Execute(Command{
+			Args: []string{},
+		})
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("argument"))
+		Expect(msg).To(ContainSubstring("required"))
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Fails if the command doesn't exist", func() {
+		result, err := executer.Execute(Command{
+			Args: []string{
+				"junk",
+			},
+		})
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring("junk"))
+		Expect(msg).To(ContainSubstring("executable"))
+		Expect(msg).To(ContainSubstring("not"))
+		Expect(msg).To(ContainSubstring("found"))
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Finds the path of the executable and runs it", func() {
+		_, err := executer.Execute(Command{
+			Args: []string{
+				"echo",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Executes command with full path name", func() {
+		_, err := executer.Execute(Command{
+			Args: []string{
+				"/usr/bin/echo",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Returns whatever the command writes to the standard output", func() {
+		result, err := executer.Execute(Command{
+			Args: []string{
+				"echo", "Hello!",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(result))
+	})
+
+	It("Adds enviroment variable", func() {
+		result, err := executer.Execute(Command{
+			Env: map[string]any{
+				"MYVAR": "myvalue",
+			},
+			Args: []string{
+				"env",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		lines := strings.Split(result, "\n")
+		Expect(lines).To(ContainElement("MYVAR=myvalue"))
+	})
+
+	It("Removes enviroment variable", func() {
+		result, err := executer.Execute(Command{
+			Env: map[string]any{
+				"HOME": nil,
+			},
+			Args: []string{
+				"env",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		lines := strings.Split(result, "\n")
+		Expect(lines).ToNot(ContainElement(MatchRegexp("^HOME=.*$")))
+	})
+
+	It("Passes command line arguments", func() {
+		result, err := executer.Execute(Command{
+			Args: []string{
+				"echo", "Hello", "world!",
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("Hello world!"))
+	})
+})

--- a/pkg/executer/mock_executer.go
+++ b/pkg/executer/mock_executer.go
@@ -35,23 +35,18 @@ func (m *MockExecuter) EXPECT() *MockExecuterMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockExecuter) Execute(command string, args ...string) (string, error) {
+func (m *MockExecuter) Execute(command Command) (string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{command}
-	for _, a := range args {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Execute", varargs...)
+	ret := m.ctrl.Call(m, "Execute", command)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockExecuterMockRecorder) Execute(command interface{}, args ...interface{}) *gomock.Call {
+func (mr *MockExecuterMockRecorder) Execute(command interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{command}, args...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecuter)(nil).Execute), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecuter)(nil).Execute), command)
 }
 
 // TempFile mocks base method.

--- a/pkg/executer/suite_test.go
+++ b/pkg/executer/suite_test.go
@@ -1,0 +1,13 @@
+package executer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestExecuter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Executer")
+}

--- a/pkg/genisoimage/genisoimage.go
+++ b/pkg/genisoimage/genisoimage.go
@@ -28,6 +28,8 @@ func NewGenIsoImage() GenIsoImage {
 func (s *genisoimage) GenerateImage(imagePath, imageName, dirPath string) error {
 	cmd := fmt.Sprintf(genDataImageCmd, imagePath, imageName, dirPath)
 	args := strings.Split(cmd, " ")
-	_, err := s.executer.Execute(args[0], args[1:]...)
+	_, err := s.executer.Execute(executer.Command{
+		Args: args,
+	})
 	return err
 }

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -66,8 +66,9 @@ func (i *installer) CreateUnconfiguredIgnition(releaseImage, pullSecret string) 
 	}
 
 	createCmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, openshiftInstallFilePath, i.EnvConfig.TempDir)
-	args := strings.Split(createCmd, " ")
-	_, err = executer.NewExecuter().Execute(args[0], args[1:]...)
+	_, err = executer.NewExecuter().Execute(executer.Command{
+		Args: strings.Fields(createCmd),
+	})
 	return filepath.Join(i.EnvConfig.TempDir, unconfiguredIgnitionFileName), err
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/openshift/appliance/pkg/executer"
@@ -85,9 +86,10 @@ func (r *registry) StartRegistry(dataDirPath string) error {
 	}
 
 	command := fmt.Sprintf(registryStartCmd, dataDirPath, r.Port, r.URI)
-	logrus.Debugf("Running registry cmd: %s", command)
-	command, formattedArgs := executer.FormatCommand(command)
-	_, err = r.Executer.Execute(command, formattedArgs...)
+	logrus.Debugf("Running registry start cmd: %s", command)
+	_, err = r.Executer.Execute(executer.Command{
+		Args: strings.Fields(command),
+	})
 	if err != nil {
 		return errors.Wrapf(err, "registry start failure")
 	}
@@ -99,10 +101,10 @@ func (r *registry) StartRegistry(dataDirPath string) error {
 }
 
 func (r *registry) StopRegistry() error {
-	logrus.Debug("Stopping registry container")
-	command, formattedArgs := executer.FormatCommand(registryStopCmd)
-	logrus.Debugf("Running registry cmd: %s", command)
-	_, err := r.Executer.Execute(command, formattedArgs...)
+	logrus.Debugf("Running registry stop cmd: %s", registryStopCmd)
+	_, err := r.Executer.Execute(executer.Command{
+		Args: strings.Fields(registryStopCmd),
+	})
 	if err != nil {
 		return errors.Wrapf(err, "registry stop failure")
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -39,11 +39,15 @@ var _ = Describe("Test Image Registry", func() {
 		dataDirPath, err := GetRegistryDataPath("/fake/path", "/data")
 		Expect(err).NotTo(HaveOccurred())
 
-		startCmd, startCmdrgs := executer.FormatCommand(fmt.Sprintf(registryStartCmd, dataDirPath, port, uri))
-		stopCmd, stopCmdrgs := executer.FormatCommand(registryStopCmd)
+		startCmd := fmt.Sprintf(registryStartCmd, dataDirPath, port, uri)
+		stopCmd := registryStopCmd
 
-		mockExecuter.EXPECT().Execute(stopCmd, stopCmdrgs).Return("", nil).Times(1)
-		mockExecuter.EXPECT().Execute(startCmd, startCmdrgs).Return("", nil).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(startCmd),
+		}).Return("", nil).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(stopCmd),
+		}).Return("", nil).Times(1)
 
 		imageRegistry := NewRegistry(
 			RegistryConfig{
@@ -61,11 +65,15 @@ var _ = Describe("Test Image Registry", func() {
 		dataDirPath, err := GetRegistryDataPath("/fake/path", "/data")
 		Expect(err).NotTo(HaveOccurred())
 
-		startCmd, startCmdrgs := executer.FormatCommand(fmt.Sprintf(registryStartCmd, dataDirPath, port, uri))
-		stopCmd, stopCmdrgs := executer.FormatCommand(registryStopCmd)
+		startCmd := fmt.Sprintf(registryStartCmd, dataDirPath, port, uri)
+		stopCmd := registryStopCmd
 
-		mockExecuter.EXPECT().Execute(stopCmd, stopCmdrgs).Return("", nil).Times(1)
-		mockExecuter.EXPECT().Execute(startCmd, startCmdrgs).Return("", errors.New("some error")).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(stopCmd),
+		}).Return("", nil).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(startCmd),
+		}).Return("", errors.New("some error")).Times(1)
 
 		imageRegistry := NewRegistry(
 			RegistryConfig{
@@ -80,9 +88,9 @@ var _ = Describe("Test Image Registry", func() {
 	})
 
 	It("Stop Registry - Success", func() {
-		stopCmd, stopCmdrgs := executer.FormatCommand(registryStopCmd)
-
-		mockExecuter.EXPECT().Execute(stopCmd, stopCmdrgs).Return("", nil).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(registryStopCmd),
+		}).Return("", nil).Times(1)
 
 		imageRegistry := NewRegistry(
 			RegistryConfig{
@@ -97,9 +105,9 @@ var _ = Describe("Test Image Registry", func() {
 	})
 
 	It("Stop Registry - Fail", func() {
-		stopCmd, stopCmdrgs := executer.FormatCommand(registryStopCmd)
-
-		mockExecuter.EXPECT().Execute(stopCmd, stopCmdrgs).Return("", errors.New("some error")).Times(1)
+		mockExecuter.EXPECT().Execute(executer.Command{
+			Args: strings.Fields(registryStopCmd),
+		}).Return("", errors.New("some error")).Times(1)
 
 		imageRegistry := NewRegistry(
 			RegistryConfig{

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -143,10 +143,10 @@ func (r *release) extractFileFromImage(image, file, outputDir string) (string, e
 	return p, nil
 }
 
-func (r *release) execute(executer executer.Executer, pullSecret, command string) (string, error) {
+func (r *release) execute(exe executer.Executer, pullSecret, command string) (string, error) {
 	executeCommand := command
 	if pullSecret != "" {
-		ps, err := executer.TempFile(r.envConfig.TempDir, "registry-config")
+		ps, err := exe.TempFile(r.envConfig.TempDir, "registry-config")
 		if err != nil {
 			return "", err
 		}
@@ -166,9 +166,9 @@ func (r *release) execute(executer executer.Executer, pullSecret, command string
 	}
 
 	logrus.Debugf("Executing command: %s", executeCommand)
-	args := strings.Split(executeCommand, " ")
-
-	stdout, err := executer.Execute(args[0], args[1:]...)
+	stdout, err := exe.Execute(executer.Command{
+		Args: strings.Fields(executeCommand),
+	})
 	if err == nil {
 		return strings.TrimSpace(stdout), nil
 	}

--- a/pkg/skopeo/skopeo.go
+++ b/pkg/skopeo/skopeo.go
@@ -32,7 +32,9 @@ func NewSkopeo() Skopeo {
 func (s *skopeo) CopyToRegistry(srcImage, dstImage string) error {
 	cmd := fmt.Sprintf(templateCopyToRegistry, srcImage, dstImage)
 	args := strings.Split(cmd, " ")
-	_, err := s.executer.Execute(args[0], args[1:]...)
+	_, err := s.executer.Execute(executer.Command{
+		Args: args,
+	})
 	return err
 }
 
@@ -43,6 +45,8 @@ func (s *skopeo) CopyToFile(imageUrl, imageName, filePath string) error {
 
 	cmd := fmt.Sprintf(templateCopyToFile, imageUrl, filePath, imageName)
 	args := strings.Split(cmd, " ")
-	_, err := s.executer.Execute(args[0], args[1:]...)
+	_, err := s.executer.Execute(executer.Command{
+		Args: args,
+	})
 	return err
 }


### PR DESCRIPTION
Currently the `Executer` interface only supports passing command line arguments. This patch adds support for also passing environment variables. For example, to execute the `oc mirror` command setting explicitly the `XDG_RUNTIME_DIR` envionment variable:

```go
result, err := executer.Execute(executer.Command{
        Env: map[string]any{
                "XDG_RUNTIME_DIR": "/my/dir",
        },
        Args: []string{
                "oc", "mirror", ...,
        },
})
if err != nil {
        ...
}
```