### PR TITLE
fix create-cluster-and-infraenv service on disconnected

### DIFF
--- a/data/services/bootstrap/create-cluster-and-infraenv.service
+++ b/data/services/bootstrap/create-cluster-and-infraenv.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Service that creates initial cluster and infraenv
+Wants=network-online.target assisted-service.service
+PartOf=assisted-service-pod.service
+After=network-online.target assisted-service.service
+ConditionPathExists=/etc/assisted/node0
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=/etc/assisted/rendezvous-host.env
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
+EnvironmentFile=/usr/local/share/assisted-service/assisted-service.env
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
+ExecStart=podman run --net host --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv --restart=on-failure -v /etc/assisted/manifests:/manifests -v /etc/assisted/extra-manifests:/extra-manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z -v /etc/containers:/etc/containers --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR $SERVICE_IMAGE /usr/local/bin/agent-installer-client register
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+
+KillMode=none
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The create-cluster-and-infraenv service fails on disconnected using 4.14.0-ec.3 release[*]
Hence, overridden the service and added '-v /etc/containers:/etc/containers' for propagating the registries.conf file.

Notes: 
* A proper [fix](https://github.com/openshift/installer/pull/7332) pushed to the installer for later.
* It won't affect connect environments as the registries.conf file doesn't have mirrors config by default.

[*] create-cluster-and-infraenv[2784]: level=fatal msg="Failed to register cluster with assisted-service: command 'oc adm release info -o template --template '{{.metadata.version}}' --insecure=true quay.io/openshift-release-dev/ocp-release@sha256:3c050cb52fdd3e65c518d4999d238ec026ef724503f275377fee6bf0d33093ab --registry-config=/tmp/registry-config1560177852' exited with non-zero exit code 1: \nerror: unable to read image quay.io/openshift-release-dev/ocp-release@sha256:3c050cb52fdd3e65c518d4999d238ec026ef724503f275377fee6bf0d33093ab: Get \"http://quay.io/v2/\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)\n"