### PR TITLE
fix support for 4.14 cluster install

### DIFF
--- a/data/scripts/bin/start-local-registry.sh.template
+++ b/data/scripts/bin/start-local-registry.sh.template
@@ -16,7 +16,9 @@ openssl req -newkey rsa:4096 -nodes -sha256 -keyout /tmp/certs/domain.key \
 
 # Apply certificates
 mkdir -p /etc/docker/certs.d/{{.RegistryDomain}}:5000
+mkdir -p /etc/containers/certs.d/{{.RegistryDomain}}:5000
 cp /tmp/certs/domain.crt /etc/docker/certs.d/{{.RegistryDomain}}:5000
+cp /tmp/certs/domain.crt /etc/containers/certs.d/{{.RegistryDomain}}:5000
 cp /tmp/certs/domain.crt /etc/pki/ca-trust/source/anchors/
 update-ca-trust extract
 

--- a/data/services/common/start-local-registry.service
+++ b/data/services/common/start-local-registry.service
@@ -4,7 +4,7 @@ Wants=network.target
 
 [Service]
 ExecStart=/usr/local/bin/start-local-registry.sh
-Type=oneshot
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -90,6 +90,8 @@ func initBlockedBootstrapImagesInfo() map[string]bool {
 		"coredns":                                  true,
 		"installer":                                true,
 		"cluster-kube-controller-manager-operator": true,
+		"cluster-version-operator":                 true,
+		"cluster-node-tuning-operator":             true,
 	}
 }
 


### PR DESCRIPTION
* Added missing images to bootstrap step.
* Added registry certificates to /etc/containers/certs.d folder.

```
NAME	  VERSION	AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.14.0-ec.3   True        False         2m      Cluster version is 4.14.0-ec.3
```