### PR TITLE
MGMT-15378: Refactor the usage of Channel to graph.ReleaseChannel

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -323,8 +323,8 @@ func (a *ApplianceConfig) validateOcpRelease() field.ErrorList {
 	}
 
 	// Validate ocpRelease.channel
-	if swag.StringValue(a.Config.OcpRelease.Channel) != "" {
-		switch graph.ReleaseChannel(*a.Config.OcpRelease.Channel) {
+	if a.Config.OcpRelease.Channel != nil {
+		switch *a.Config.OcpRelease.Channel {
 		case graph.ReleaseChannelStable:
 		case graph.ReleaseChannelFast:
 		case graph.ReleaseChannelCandidate:
@@ -335,7 +335,8 @@ func (a *ApplianceConfig) validateOcpRelease() field.ErrorList {
 				"Unsupported OCP release channel (supported channels: stable|fast|eus|candidate)")}...)
 		}
 	} else {
-		a.Config.OcpRelease.Channel = swag.String(string(graph.ReleaseChannelStable))
+		channel := graph.ReleaseChannelStable
+		a.Config.OcpRelease.Channel = &channel
 	}
 
 	// Validate ocpRelease.cpuArchitecture

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -68,7 +68,7 @@ type GraphConfig struct {
 	Arch              string
 	Version           string
 	CincinnatiAddress *string
-	Channel           *string
+	Channel           *ReleaseChannel
 }
 
 type graph struct {
@@ -87,7 +87,8 @@ func NewGraph(config GraphConfig) Graph {
 	}
 
 	if config.Channel == nil {
-		config.Channel = swag.String(string(ReleaseChannelStable))
+		channel := ReleaseChannelStable
+		config.Channel = &channel
 	}
 	return &graph{
 		GraphConfig: config,

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -72,10 +72,11 @@ var _ = Describe("Test Graph", func() {
 	)
 
 	BeforeEach(func() {
+		channel := ReleaseChannelStable
 		graphConfig = GraphConfig{
 			HTTPClient: &ClientMock{},
 			Arch:       "amd64",
-			Channel:    swag.String(string(ReleaseChannelStable)),
+			Channel:    &channel,
 		}
 	})
 

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Test Installer", func() {
 
 	It("GetInstallerDownloadURL - x86_64 stable", func() {
 		version := "4.13.1"
-		channel := swag.String(string(graph.ReleaseChannelStable))
+		channel := graph.ReleaseChannelStable
 		cpuArc := swag.String(config.CpuArchitectureX86)
 		installerConfig := InstallerConfig{
 			Executer:  mockExecuter,
@@ -38,7 +38,7 @@ var _ = Describe("Test Installer", func() {
 				Config: &types.ApplianceConfig{
 					OcpRelease: types.ReleaseImage{
 						Version:         version,
-						Channel:         channel,
+						Channel:         &channel,
 						CpuArchitecture: cpuArc,
 					},
 				},
@@ -53,7 +53,7 @@ var _ = Describe("Test Installer", func() {
 
 	It("GetInstallerDownloadURL - aarch64 candidate", func() {
 		version := "4.13.2"
-		channel := swag.String(string(graph.ReleaseChannelCandidate))
+		channel := graph.ReleaseChannelCandidate
 		cpuArc := swag.String(config.CpuArchitectureAARCH64)
 		installerConfig := InstallerConfig{
 			Executer:  mockExecuter,
@@ -62,7 +62,7 @@ var _ = Describe("Test Installer", func() {
 				Config: &types.ApplianceConfig{
 					OcpRelease: types.ReleaseImage{
 						Version:         version,
-						Channel:         channel,
+						Channel:         &channel,
 						CpuArchitecture: cpuArc,
 					},
 				},
@@ -77,7 +77,7 @@ var _ = Describe("Test Installer", func() {
 
 	It("CreateUnconfiguredIgnition - DebugBaseIgnition: false", func() {
 		version := "4.13.1"
-		channel := swag.String(string(graph.ReleaseChannelStable))
+		channel := graph.ReleaseChannelStable
 		cpuArc := swag.String(config.CpuArchitectureX86)
 		installerConfig := InstallerConfig{
 			Executer: mockExecuter,
@@ -88,7 +88,7 @@ var _ = Describe("Test Installer", func() {
 				Config: &types.ApplianceConfig{
 					OcpRelease: types.ReleaseImage{
 						Version:         version,
-						Channel:         channel,
+						Channel:         &channel,
 						CpuArchitecture: cpuArc,
 					},
 				},
@@ -103,7 +103,7 @@ var _ = Describe("Test Installer", func() {
 
 	It("CreateUnconfiguredIgnition - DebugBaseIgnition: true", func() {
 		version := "4.13.1"
-		channel := swag.String(string(graph.ReleaseChannelStable))
+		channel := graph.ReleaseChannelStable
 		cpuArc := swag.String(config.CpuArchitectureX86)
 		tmpDir := "/path/to/tempdir"
 
@@ -120,7 +120,7 @@ var _ = Describe("Test Installer", func() {
 				Config: &types.ApplianceConfig{
 					OcpRelease: types.ReleaseImage{
 						Version:         version,
-						Channel:         channel,
+						Channel:         &channel,
 						CpuArchitecture: cpuArc,
 					},
 				},

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -50,6 +50,7 @@ func GetGuestfishScriptTemplateData(diskSize, recoveryIsoSize, dataIsoSize int64
 
 func GetImageSetTemplateData(applianceConfig *config.ApplianceConfig, blockedImages string, additionalImages string) interface{} {
 	version := applianceConfig.Config.OcpRelease.Version
+	channel := *applianceConfig.Config.OcpRelease.Channel
 	return struct {
 		Architectures    string
 		ChannelName      string
@@ -59,7 +60,7 @@ func GetImageSetTemplateData(applianceConfig *config.ApplianceConfig, blockedIma
 		AdditionalImages string
 	}{
 		Architectures:    config.GetReleaseArchitectureByCPU(applianceConfig.GetCpuArchitecture()),
-		ChannelName:      fmt.Sprintf("%s-%s", swag.StringValue(applianceConfig.Config.OcpRelease.Channel), toMajorMinor(version)),
+		ChannelName:      fmt.Sprintf("%s-%s", channel, toMajorMinor(version)),
 		MinVersion:       version,
 		MaxVersion:       version,
 		BlockedImages:    blockedImages,

--- a/pkg/types/appliance_config_type.go
+++ b/pkg/types/appliance_config_type.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/openshift/appliance/pkg/graph"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,10 +21,10 @@ type ApplianceConfig struct {
 }
 
 type ReleaseImage struct {
-	Version         string  `json:"version"`
-	Channel         *string `json:"channel"`
-	CpuArchitecture *string `json:"cpuArchitecture"`
-	URL             *string `json:"url"`
+	Version         string                `json:"version"`
+	Channel         *graph.ReleaseChannel `json:"channel"`
+	CpuArchitecture *string               `json:"cpuArchitecture"`
+	URL             *string               `json:"url"`
 }
 
 type ImageRegistry struct {


### PR DESCRIPTION
Channel has a type of graph.ReleaseChannel, but it is currently casted as string in many places in the code for no good reason.