### PR TITLE
Added support for cloning the appliance with virt-resize

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -89,7 +89,10 @@ ocpRelease:
   # Default: %s
   # [Optional]
   cpuArchitecture: cpu-architecture
-# Virtual size of the appliance disk image (at least %dGiB)
+# If specified, should be at least %dGiB.
+# If not specified, the disk image should be resized when 
+# cloning to a device (e.g. using virt-resize tool).
+# [Optional]
 diskSizeGB: disk-size
 # PullSecret required for mirroring the OCP release payload
 pullSecret: pull-secret
@@ -355,7 +358,10 @@ func (a *ApplianceConfig) validateOcpRelease() field.ErrorList {
 }
 
 func (a *ApplianceConfig) validateDiskSize() error {
-	if a.Config.DiskSizeGB < MinDiskSize {
+	if a.Config.DiskSizeGB == nil {
+		return nil
+	}
+	if *a.Config.DiskSizeGB < MinDiskSize {
 		return fmt.Errorf("diskSizeGB must be at least %d GiB", MinDiskSize)
 	}
 	return nil

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -30,7 +30,7 @@ func GetGuestfishScriptTemplateData(diskSize, recoveryIsoSize, dataIsoSize int64
 
 	return struct {
 		ApplianceFile, RecoveryIsoFile, DataIsoFile, CoreOSImage, RecoveryPartitionName, DataPartitionName, ReservedPartitionGUID, CfgFile string
-		DiskSize, RecoveryStartSector, RecoveryEndSector, DataStartSector, DataEndSector, RootEndSector                                    int64
+		DiskSize, RecoveryStartSector, RecoveryEndSector, DataStartSector, DataEndSector, RootStartSector, RootEndSector                   int64
 	}{
 		ApplianceFile:         applianceImageFile,
 		RecoveryIsoFile:       recoveryIsoFile,
@@ -41,7 +41,8 @@ func GetGuestfishScriptTemplateData(diskSize, recoveryIsoSize, dataIsoSize int64
 		RecoveryEndSector:     partitionsInfo.RecoveryPartition.EndSector,
 		DataStartSector:       partitionsInfo.DataPartition.StartSector,
 		DataEndSector:         partitionsInfo.DataPartition.EndSector,
-		RootEndSector:         partitionsInfo.RecoveryPartition.StartSector - 1,
+		RootStartSector:       partitionsInfo.RootPartition.StartSector,
+		RootEndSector:         partitionsInfo.RootPartition.EndSector,
 		RecoveryPartitionName: consts.RecoveryPartitionName,
 		DataPartitionName:     consts.DataPartitionName,
 		ReservedPartitionGUID: consts.ReservedPartitionGUID,

--- a/pkg/templates/scripts/guestfish/guestfish.sh.template
+++ b/pkg/templates/scripts/guestfish/guestfish.sh.template
@@ -12,6 +12,16 @@ copy-device-to-device /dev/sdb /dev/sda
 # Move backup GPT data structures to the end of the disk
 part-expand-gpt /dev/sda
 
+# Remove the root partition
+# Note: we don't need CoreOS root partition as we boot from recovery partition.
+part-del /dev/sda 4
+
+# Create an empty root partition (for resizing when cloning the disk image)
+part-add /dev/sda p {{.RootStartSector}} {{.RootEndSector}}
+
+# Set root partition name
+part-set-name /dev/sda 4 root
+
 # Create recovery partition
 part-add /dev/sda p {{.RecoveryStartSector}} {{.RecoveryEndSector}}
 
@@ -31,12 +41,6 @@ part-set-name /dev/sda 6 {{.DataPartitionName}}
 # Set partition as Linux reserved partition
 part-set-gpt-type /dev/sda 5 {{.ReservedPartitionGUID}}
 part-set-gpt-type /dev/sda 6 {{.ReservedPartitionGUID}}
-
-# Resize the root partition (needed for coreos-installer)
-part-resize /dev/sda 4 {{.RootEndSector}}
-
-# Format root partition (content is redundant as we boot from recovery)
-mkfs xfs /dev/sda4
 
 # Handle GRUB
 mount /dev/sda3 /

--- a/pkg/types/appliance_config_type.go
+++ b/pkg/types/appliance_config_type.go
@@ -13,7 +13,7 @@ type ApplianceConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	OcpRelease    ReleaseImage   `json:"ocpRelease"`
-	DiskSizeGB    int            `json:"diskSizeGb"`
+	DiskSizeGB    *int           `json:"diskSizeGb"`
 	PullSecret    string         `json:"pullSecret"`
 	SshKey        *string        `json:"sshKey"`
 	UserCorePass  *string        `json:"userCorePass"`


### PR DESCRIPTION
* The 'diskSizeGB' property is now optional in appliance-config.yaml
* When 'diskSizeGB' is not specified, the virtual size is calcualted according to the actual content (i.e. to be as compact as possible). and the partition size is minimal.
* Added details for virt-resize usage to the use-guide.