### PR TITLE
Fix SSH login on bootstrap

### DIFF
--- a/pkg/asset/ignition/bootstrap_ignition.go
+++ b/pkg/asset/ignition/bootstrap_ignition.go
@@ -153,9 +153,6 @@ func (i *BootstrapIgnition) Generate(dependencies asset.Parents) error {
 
 	// Add public ssh key
 	if applianceConfig.Config.SshKey != nil {
-		passwdUser := igntypes.PasswdUser{
-			Name: "core",
-		}
 		passwdUser.SSHAuthorizedKeys = []igntypes.SSHAuthorizedKey{
 			igntypes.SSHAuthorizedKey(*applianceConfig.Config.SshKey),
 		}


### PR DESCRIPTION
Removed redundant 'passwdUser' var declaration (shadowed the one declared on line 130).