### PR TITLE
Calculate root partition size precisely

### DIFF
--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -25,8 +25,8 @@ func GetUserCfgTemplateData(grubMenuEntryName string, grubDefault int) interface
 	}
 }
 
-func GetGuestfishScriptTemplateData(diskSize, recoveryIsoSize, dataIsoSize int64, baseImageFile, applianceImageFile, recoveryIsoFile, dataIsoFile, cfgFile string) interface{} {
-	partitionsInfo := NewPartitions().GetAgentPartitions(diskSize, recoveryIsoSize, dataIsoSize)
+func GetGuestfishScriptTemplateData(diskSize, baseIsoSize, recoveryIsoSize, dataIsoSize int64, baseImageFile, applianceImageFile, recoveryIsoFile, dataIsoFile, cfgFile string) interface{} {
+	partitionsInfo := NewPartitions().GetAgentPartitions(diskSize, baseIsoSize, recoveryIsoSize, dataIsoSize)
 
 	return struct {
 		ApplianceFile, RecoveryIsoFile, DataIsoFile, CoreOSImage, RecoveryPartitionName, DataPartitionName, ReservedPartitionGUID, CfgFile string

--- a/pkg/templates/partitions_test.go
+++ b/pkg/templates/partitions_test.go
@@ -8,15 +8,16 @@ import (
 
 var _ = Describe("Test Partitions", func() {
 	var (
-		testPartitions                         *AgentPartitions
-		diskSize, recoveryIsoSize, dataIsoSize int64
+		testPartitions                                      *AgentPartitions
+		diskSize, baseIsoSize, recoveryIsoSize, dataIsoSize int64
 	)
 
 	BeforeEach(func() {
 		diskSize = 200
+		baseIsoSize = conversions.GibToBytes(2)
 		recoveryIsoSize = conversions.GibToBytes(5)
 		dataIsoSize = conversions.GibToBytes(30)
-		testPartitions = NewPartitions().GetAgentPartitions(diskSize, recoveryIsoSize, dataIsoSize)
+		testPartitions = NewPartitions().GetAgentPartitions(diskSize, baseIsoSize, recoveryIsoSize, dataIsoSize)
 	})
 
 	It("partitions are aligned to 4K", func() {


### PR DESCRIPTION
The root partition must be precisely calculated now as we manually create it in guestfish script.
I.e. before supporting a compact image, the root partition was resized automatically.
But now, we are giving exact start and end sectors. Thus, the partition size can be calculated according to the disk size and its content. Without this fix, the root partition size won't expand from 8GiB when specifying a disk size.