### PR TITLE
MGMT-15673: set core pass on installation step

### DIFF
--- a/data/services/install/set-core-pass.service.template
+++ b/data/services/install/set-core-pass.service.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=Service for setting user core password
+
+[Service]
+Environment=CORE_PASS_HASH={{.CorePassHash}}
+ExecStart=/usr/sbin/usermod --password $CORE_PASS_HASH core
+Type=oneshot
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -128,11 +128,11 @@ func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, regist
 	}
 }
 
-func GetInstallIgnitionTemplateData(registryDataPath string) interface{} {
+func GetInstallIgnitionTemplateData(registryDataPath, corePassHash string) interface{} {
 	return struct {
 		IsBootstrapStep bool
 
-		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage string
+		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage, CorePassHash string
 	}{
 		IsBootstrapStep: false,
 
@@ -141,6 +141,7 @@ func GetInstallIgnitionTemplateData(registryDataPath string) interface{} {
 		RegistryDomain:   registry.RegistryDomain,
 		RegistryFilePath: consts.RegistryFilePath,
 		RegistryImage:    consts.RegistryImage,
+		CorePassHash:     corePassHash,
 	}
 }
 


### PR DESCRIPTION
Added a service for setting the user core password (when specified). This is required to ensure the pass is set after reboot (i.e. as opposed to setting using the ignition).