### PR TITLE
MGMT-16043: fix Subscription example in user-guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -276,7 +276,7 @@ metadata:
 spec:
   installPlanApproval: Automatic
   name: elasticsearch-operator
-  source: redhat-operator-index
+  source: cs-redhat-operator-index
   channel: stable
   sourceNamespace: openshift-marketplace
 ```


### PR DESCRIPTION
The new oc-mirror (>=4.14) creates a CatalogSource with 'cs-' prefix when mirroring operators.
Hence, fixed the example in the user guide.