### PR TITLE
MGMT-16434: added --cache flag to clean cmd

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -14,6 +14,10 @@ import (
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 )
 
+var (
+	cleanCache bool
+)
+
 func NewCleanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clean",
@@ -38,9 +42,17 @@ func NewCleanCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 
+			if cleanCache {
+				// Remove cache dir
+				if err := os.RemoveAll(filepath.Join(rootOpts.dir, config.CacheDir)); err != nil {
+					logrus.Fatal(err)
+				}
+			}
+
 			logrus.Infof("Cleanup complete")
 		},
 	}
+	cmd.Flags().BoolVar(&cleanCache, "cache", false, "Clean also the builder cache directory")
 	return cmd
 }
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -327,9 +327,13 @@ INFO Download openshift-install from: https://mirror.openshift.com/pub/openshift
 ### Rebuild
 
 Before rebuilding the appliance, e.g. for changing `diskSizeGB` or `ocpRelease`, use the `clean` command. This command removes the temp folder and prepares the `assets` folder for a rebuild.
-Note: the command keeps the `cache` folder under `assets` intact.
 ```shell
 sudo podman run --rm -it -v $APPLIANCE_ASSETS:/assets:Z $APPLIANCE_IMAGE clean
+```
+
+Note: the command keeps the `cache` folder under `assets` intact, use the `--cache` flag to clean the entire cache as well.
+```shell
+sudo podman run --rm -it -v $APPLIANCE_ASSETS:/assets:Z $APPLIANCE_IMAGE clean --cache
 ```
 
 #### Demo


### PR DESCRIPTION
In order to clean the assets directory including the builder cache, the clean command now supports --cache flag. The defualt is false as the common use case for cleaning is to rebuild the appliance using data from cache.