### PR TITLE
Fix path for registry data

### DIFF
--- a/pkg/asset/data/data_iso.go
+++ b/pkg/asset/data/data_iso.go
@@ -90,10 +90,7 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 			applianceConfig.Config.OcpRelease.Version),
 		envConfig,
 	)
-	registryDir, err := registry.GetRegistryDataPath(envConfig.TempDir, bootstrapMirrorDir)
-	if err != nil {
-		return log.StopSpinner(spinner, err)
-	}
+	registryDir := filepath.Join(envConfig.TempDir, bootstrapMirrorDir)
 	spinner.DirToMonitor = registryDir
 	bootstrapImageRegistry := registry.NewRegistry(
 		registry.RegistryConfig{
@@ -101,13 +98,13 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 			URI:         swag.StringValue(applianceConfig.Config.ImageRegistry.URI),
 			Port:        swag.IntValue(applianceConfig.Config.ImageRegistry.Port),
 		})
-	if err = bootstrapImageRegistry.StartRegistry(); err != nil {
+	if err := bootstrapImageRegistry.StartRegistry(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	if err = r.MirrorBootstrapImages(); err != nil {
+	if err := r.MirrorBootstrapImages(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	if err = log.StopSpinner(spinner, nil); err != nil {
+	if err := log.StopSpinner(spinner, nil); err != nil {
 		return err
 	}
 
@@ -121,10 +118,7 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 			applianceConfig.Config.OcpRelease.Version),
 		envConfig,
 	)
-	registryDir, err = registry.GetRegistryDataPath(envConfig.TempDir, installMirrorDir)
-	if err != nil {
-		return log.StopSpinner(spinner, err)
-	}
+	registryDir = filepath.Join(envConfig.TempDir, installMirrorDir)
 	spinner.DirToMonitor = registryDir
 	releaseImageRegistry := registry.NewRegistry(
 		registry.RegistryConfig{
@@ -133,16 +127,16 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 			Port:        swag.IntValue(applianceConfig.Config.ImageRegistry.Port),
 		})
 
-	if err = releaseImageRegistry.StartRegistry(); err != nil {
+	if err := releaseImageRegistry.StartRegistry(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	if err = r.MirrorInstallImages(); err != nil {
+	if err := r.MirrorInstallImages(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	if err = releaseImageRegistry.StopRegistry(); err != nil {
+	if err := releaseImageRegistry.StopRegistry(); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
-	if err = log.StopSpinner(spinner, nil); err != nil {
+	if err := log.StopSpinner(spinner, nil); err != nil {
 		return err
 	}
 
@@ -154,7 +148,7 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 	)
 	spinner.FileToMonitor = dataIsoName
 	imageGen := genisoimage.NewGenIsoImage(nil)
-	if err = imageGen.GenerateImage(envConfig.CacheDir, dataIsoName, filepath.Join(envConfig.TempDir, dataDir)); err != nil {
+	if err := imageGen.GenerateImage(envConfig.CacheDir, dataIsoName, filepath.Join(envConfig.TempDir, dataDir)); err != nil {
 		return log.StopSpinner(spinner, err)
 	}
 	return log.StopSpinner(spinner, a.updateAsset(envConfig))

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/openshift/appliance/pkg/executer"
@@ -104,12 +103,4 @@ func (r *registry) StopRegistry() error {
 
 	}
 	return nil
-}
-
-func GetRegistryDataPath(directory, subDirectory string) (string, error) {
-	pwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(pwd, directory, subDirectory), nil
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,9 +38,9 @@ var _ = Describe("Test Image Registry", func() {
 	})
 
 	It("Start Registry - Valid Config", func() {
-		dataDirPath, err := GetRegistryDataPath("/fake/path", "/data")
-		Expect(err).NotTo(HaveOccurred())
-
+		pwd, err := os.Getwd()
+        Expect(err).NotTo(HaveOccurred())
+		dataDirPath := filepath.Join(pwd, "/fake/path", "/data")
 		mockExecuter.EXPECT().Execute(fmt.Sprintf(registryStartCmd, dataDirPath, port, uri)).Return("", nil).Times(1)
 		mockExecuter.EXPECT().Execute(registryStopCmd).Return("", nil).Times(1)
 
@@ -56,9 +58,9 @@ var _ = Describe("Test Image Registry", func() {
 	})
 
 	It("Start Registry - fail to start", func() {
-		dataDirPath, err := GetRegistryDataPath("/fake/path", "/data")
-		Expect(err).NotTo(HaveOccurred())
-
+		pwd, err := os.Getwd()
+        Expect(err).NotTo(HaveOccurred())
+		dataDirPath := filepath.Join(pwd, "/fake/path", "/data")
 		startCmd := fmt.Sprintf(registryStartCmd, dataDirPath, port, uri)
 
 		mockExecuter.EXPECT().Execute(registryStopCmd).Return("", nil).Times(1)


### PR DESCRIPTION
The registry data path is constructed with the working directory, which is redundant as the temp directory is already absolute.