### PR TITLE
Fix registry data path on binary flow

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/openshift/appliance/pkg/executer"
@@ -110,6 +111,11 @@ func GetRegistryDataPath(directory, subDirectory string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
+	}
+	if strings.HasPrefix(directory, pwd) {
+		// Removes the working directory if already exists
+		// (happens when using the openshift-appliance binary flow)
+		directory = strings.ReplaceAll(directory, pwd, "")
 	}
 	return filepath.Join(pwd, directory, subDirectory), nil
 }


### PR DESCRIPTION
The registry data path is constructed with the working directory, which is redundant as the temp directory is already absolute (when using the openshift-appliance binary flow).