### PR TITLE
MGMT-16815: add missing services to install ignition

### DIFF
--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/go-openapi/swag"
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/consts"
 	ignitionutil "github.com/openshift/appliance/pkg/ignition"
@@ -79,7 +80,7 @@ func (i *InstallIgnition) Generate(dependencies asset.Parents) error {
 		corePassHash = string(passBytes)
 	}
 
-	if applianceConfig.Config.StopLocalRegistry != nil {
+	if swag.BoolValue(applianceConfig.Config.StopLocalRegistry) {
 		installServices = append(installServices, "stop-local-registry.service")
 		installScripts = append(installScripts, "stop-local-registry.sh")
 	}
@@ -89,6 +90,11 @@ func (i *InstallIgnition) Generate(dependencies asset.Parents) error {
 
 	// Add services common for bootstrap and install
 	if err := bootstrap.AddSystemdUnits(&i.Config, "services/common", templateData, installServices); err != nil {
+		return err
+	}
+
+	// Add services exclusive for install
+	if err := bootstrap.AddSystemdUnits(&i.Config, "services/install", templateData, installServices); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When 'StopLocalRegistry' is enabled in ApplianceConfig, the stop-local-registry service should be added to the install ignition. Since the service is under 'data/services/install' folder, adding its content to the install ignition.