### PR TITLE
Download installer binary by extract command from release payload

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -98,7 +98,7 @@ func (i *installer) downloadInstallerBinary() (string, error) {
 		i.EnvConfig,
 	)
 
-	logrus.Debugf("Fetch openshift-install binary from release payload %s", *i.ApplianceConfig.Config.OcpRelease.URL)
+	logrus.Debugf("Fetch openshift-install binary from release payload")
 	stdout, err := i.Release.ExtractCommand(installerBinaryName, i.EnvConfig.CacheDir)
 	if err != nil {
 		logrus.Errorf("%s", stdout)
@@ -113,7 +113,8 @@ func (i *installer) downloadInstallerBinary() (string, error) {
 	installerBinaryPath := filepath.Join(i.EnvConfig.CacheDir, installerBinaryName)
 	err = os.Chmod(installerBinaryPath, 0755)
 	if err != nil {
-		return "", err
+		// return "", err
+		logrus.Warnf("%s", err)
 	}
 	return installerBinaryPath, nil
 }

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Test Installer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		cmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, installerBinaryName, tmpDir)
 		mockExecuter.EXPECT().Execute(cmd).Return("", nil).Times(1)
+		mockRelease.EXPECT().ExtractCommand(installerBinaryName, "").Return("", nil).Times(1)
 
 		installerConfig := InstallerConfig{
 			Executer: mockExecuter,

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Test Installer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		cmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, installerBinaryName, tmpDir)
 		mockExecuter.EXPECT().Execute(cmd).Return("", nil).Times(1)
-		mockRelease.EXPECT().ExtractCommand(installerBinaryName, "").Return("", nil).Times(1)
+		
 
 		installerConfig := InstallerConfig{
 			Executer: mockExecuter,
@@ -110,6 +110,7 @@ var _ = Describe("Test Installer", func() {
 			},
 		}
 		testInstaller = NewInstaller(installerConfig)
+		mockRelease.EXPECT().ExtractCommand(installerBinaryName, installerConfig.EnvConfig.CacheDir).Return("", nil).Times(1)
 
 		res, err := testInstaller.CreateUnconfiguredIgnition()
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/openshift/appliance/pkg/graph"
+	"github.com/openshift/appliance/pkg/release"
 	"github.com/openshift/appliance/pkg/types"
 
 	"github.com/golang/mock/gomock"
@@ -20,12 +21,14 @@ var _ = Describe("Test Installer", func() {
 	var (
 		ctrl          *gomock.Controller
 		mockExecuter  *executer.MockExecuter
+		mockRelease   *release.MockRelease
 		testInstaller Installer
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockExecuter = executer.NewMockExecuter(ctrl)
+		mockRelease = release.NewMockRelease(ctrl)
 	})
 
 	It("GetInstallerDownloadURL - x86_64 stable", func() {
@@ -34,6 +37,7 @@ var _ = Describe("Test Installer", func() {
 		cpuArc := swag.String(config.CpuArchitectureX86)
 		installerConfig := InstallerConfig{
 			Executer:  mockExecuter,
+			Release:   mockRelease,
 			EnvConfig: &config.EnvConfig{},
 			ApplianceConfig: &config.ApplianceConfig{
 				Config: &types.ApplianceConfig{
@@ -58,6 +62,7 @@ var _ = Describe("Test Installer", func() {
 		cpuArc := swag.String(config.CpuArchitectureAARCH64)
 		installerConfig := InstallerConfig{
 			Executer:  mockExecuter,
+			Release:   mockRelease,
 			EnvConfig: &config.EnvConfig{},
 			ApplianceConfig: &config.ApplianceConfig{
 				Config: &types.ApplianceConfig{
@@ -88,6 +93,7 @@ var _ = Describe("Test Installer", func() {
 
 		installerConfig := InstallerConfig{
 			Executer: mockExecuter,
+			Release:  mockRelease,
 			EnvConfig: &config.EnvConfig{
 				DebugBaseIgnition: false,
 				TempDir:           tmpDir,
@@ -120,6 +126,7 @@ var _ = Describe("Test Installer", func() {
 
 		installerConfig := InstallerConfig{
 			Executer: mockExecuter,
+			Release:  mockRelease,
 			EnvConfig: &config.EnvConfig{
 				DebugBaseIgnition: true,
 				TempDir:           tmpDir,

--- a/pkg/release/mock_release.go
+++ b/pkg/release/mock_release.go
@@ -56,6 +56,11 @@ func (m *MockRelease) ExtractCommand(command string, dest string) (string, error
 	return ret0, ret1
 }
 
+func (mr *MockReleaseMockRecorder) ExtractCommand(command string, dest string) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractCommand", reflect.TypeOf((*MockRelease)(nil).ExtractCommand), command, dest)
+}
+
 // GetImageFromRelease mocks base method.
 func (m *MockRelease) GetImageFromRelease(imageName string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/release/mock_release.go
+++ b/pkg/release/mock_release.go
@@ -48,6 +48,14 @@ func (mr *MockReleaseMockRecorder) ExtractFile(image, filename interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFile", reflect.TypeOf((*MockRelease)(nil).ExtractFile), image, filename)
 }
 
+func (m *MockRelease) ExtractCommand(command string, dest string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractCommand", command, dest)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetImageFromRelease mocks base method.
 func (m *MockRelease) GetImageFromRelease(imageName string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
From recent openshift version, installer has been included in release payload. For reducing complexity, we should download installer from release payload, other than depending on another download resource.