### PR TITLE
MGMT-17049: Unconfigure local registry if stopLocalRegistry is set to true

### DIFF
--- a/data/scripts/bin/stop-local-registry.sh.template
+++ b/data/scripts/bin/stop-local-registry.sh.template
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
+export KUBECONFIG="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig"
+
 # Wait for cluster to be ready
-kubeconfig=/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig
-until [ "$(sudo oc get clusterversion --kubeconfig "${kubeconfig}" -o jsonpath='{.items[*].status.conditions[?(@.type=="Available")].status}')" == "True" ];
+until [ "$(sudo -E oc get clusterversion -o jsonpath='{.items[*].status.conditions[?(@.type=="Available")].status}')" == "True" ];
 do
   echo "Waiting for the cluster to be ready..."
   sleep 60
@@ -11,3 +12,13 @@ done
 # Stop local registry
 echo "Stopping the local registry..."
 sudo systemctl stop start-local-registry.service
+
+# Remove selector label set in 99-(master|worker)-generated-registries
+# This will delete mirror configuration in /etc/containers/registries.conf
+for role in master worker
+do
+  sudo -E oc label mc "99-${role}-generated-registries" machineconfiguration.openshift.io/role-
+  # Pause and resume the machineconfigpool to force a reconciliation
+  sudo -E oc patch --type=merge --patch='{"spec":{"paused":true}}' "machineconfigpool/${role}"
+  sudo -E oc patch --type=merge --patch='{"spec":{"paused":false}}' "machineconfigpool/${role}"
+done


### PR DESCRIPTION
The appliance installation adds a mirroring configuration in `/etc/containers/registries.conf` to use the local registry.
If we set the option `stopLocalRegistry` to true this configuration could interfere with other pulling processes because the local registry will not be available. To avoid that situation, the mirroring configuration should be removed in this scenario.