### PR TITLE
MGMT-17097: Fix SSHAuthorizedKeys in installation and post-installation phases

### DIFF
--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -130,11 +130,11 @@ func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, regist
 	}
 }
 
-func GetInstallIgnitionTemplateData(registryDataPath, corePassHash string) interface{} {
+func GetInstallIgnitionTemplateData(registryDataPath string) interface{} {
 	return struct {
 		IsBootstrapStep bool
 
-		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage, CorePassHash string
+		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage string
 	}{
 		IsBootstrapStep: false,
 
@@ -143,7 +143,6 @@ func GetInstallIgnitionTemplateData(registryDataPath, corePassHash string) inter
 		RegistryDomain:   registry.RegistryDomain,
 		RegistryFilePath: consts.RegistryFilePath,
 		RegistryImage:    consts.RegistryImage,
-		CorePassHash:     corePassHash,
 	}
 }
 


### PR DESCRIPTION
This PR fixes the creation of SSH authorized keys files during the installation and post-installation phases.
Currently, when the appliance installation completes, it is not possible log into the nodes using SSH.
After installation, the _MachineConfig_ files `99-master-set-core-pass` and `99-worker-set-core-pass` overwrite the user "_core_" settings and remove `authorized_keys`.
With this PR, the `sshKeys` value set in the `appliance-config.yaml` file will also be added to MachineConfig objects.