### PR TITLE
MGMT-17330: Use oc-mirror from stable-4.14

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -30,7 +30,7 @@ RUN dnf -y install libguestfs-tools genisoimage coreos-installer && dnf clean al
 ENV LIBGUESTFS_BACKEND=direct
 
 # Download oc-mirror
-RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/oc-mirror.tar.gz \
+RUN curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.14/oc-mirror.tar.gz \
     | tar xvzf - -C /usr/local/bin && \
     chmod +x /usr/local/bin/oc-mirror
 


### PR DESCRIPTION
Changed download url of oc-mirror to stable-4.14.
This is mitigating the following  error when using a newer oc-mirror:
```
version `GLIBC_2.34' not found (required by /usr/local/bin/oc-mirror)
```