### PR TITLE
NO-ISSUE: Fix grub menu for 4.16

### DIFF
--- a/pkg/asset/appliance/appliance_diskimage.go
+++ b/pkg/asset/appliance/appliance_diskimage.go
@@ -54,7 +54,7 @@ func (a *ApplianceDiskImage) Generate(dependencies asset.Parents) error {
 	// Render user.cfg
 	if err := templates.RenderTemplateFile(
 		consts.UserCfgTemplateFile,
-		templates.GetUserCfgTemplateData(consts.GrubMenuEntryName, consts.GrubDefault),
+		templates.GetUserCfgTemplateData(consts.GrubMenuEntryName),
 		envConfig.TempDir); err != nil {
 		return log.StopSpinner(spinner, err)
 	}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -7,12 +7,10 @@ const (
 	// user.cfg template
 	UserCfgTemplateFile = "scripts/grub/user.cfg.template"
 	GrubTimeout         = 10
-	GrubDefault         = 0
 	GrubMenuEntryName   = "Agent-Based Installer"
 	// For installation ignition
 	GrubMenuEntryNameRecovery = "Recovery: Agent-Based Installer (Reinstall Cluster)"
-	GrubDefaultRecovery       = 1
-	UserCfgFilePath           = "/boot/grub2/user.cfg"
+	GrubCfgFilePath           = "/boot/grub2/grub.cfg"
 
 	// guestfish.sh template
 	GuestfishScriptTemplateFile = "scripts/guestfish/guestfish.sh.template"

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -13,13 +13,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetUserCfgTemplateData(grubMenuEntryName string, grubDefault int) interface{} {
+func GetUserCfgTemplateData(grubMenuEntryName string) interface{} {
 	return struct {
-		GrubTimeout, GrubDefault                 int
+		GrubTimeout                              int
 		GrubMenuEntryName, RecoveryPartitionName string
 	}{
 		GrubTimeout:           consts.GrubTimeout,
-		GrubDefault:           grubDefault,
 		GrubMenuEntryName:     grubMenuEntryName,
 		RecoveryPartitionName: consts.RecoveryPartitionName,
 	}

--- a/pkg/templates/scripts/grub/user.cfg.template
+++ b/pkg/templates/scripts/grub/user.cfg.template
@@ -1,5 +1,4 @@
 set timeout={{.GrubTimeout}}
-set default={{.GrubDefault}}
 menuentry '{{.GrubMenuEntryName}}' --class gnu-linux --class gnu --class os {
   search --set=root --label {{.RecoveryPartitionName}}
   linux /images/pxeboot/vmlinuz coreos.liveiso={{.RecoveryPartitionName}} random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ignition.firstboot ignition.platform.id=metal


### PR DESCRIPTION
Append the content of user.cfg to grub.cfg in order to prevent duplicate menu entries. For details see:
- https://github.com/coreos/fedora-coreos-tracker/issues/805
- https://github.com/coreos/fedora-coreos-config/blob/5c1ac4e7d4a596efac69a3eb78061dc2f59e94fb/overlay.d/40grub/usr/lib/bootupd/grub2-static/configs.d/70_coreos-user.cfg