### PR TITLE
build: fix gocov failure

### DIFF
--- a/Dockerfile.openshift-appliance-build
+++ b/Dockerfile.openshift-appliance-build
@@ -8,8 +8,8 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
         go install github.com/golang/mock/mockgen@v1.6.0 && \
         go install github.com/vektra/mockery/v2@v2.9.6 && \
         go install gotest.tools/gotestsum@v1.6.3 && \
-        go install github.com/axw/gocov/gocov@latest && \
-        go install github.com/AlekSi/gocov-xml@latest
+        go install github.com/axw/gocov/gocov@v1.1.0 && \
+        go install github.com/AlekSi/gocov-xml@v1.1.0
 
 FROM quay.io/centos/centos:stream9
 


### PR DESCRIPTION
```
go: downloading github.com/axw/gocov v1.2.1
go: github.com/axw/gocov/gocov@latest: github.com/axw/gocov@v1.2.1 requires go >= 1.22.0 (running go 1.21.13; GOTOOLCHAIN=local)
error: build error: building at STEP "RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.0 &&         go install golang.org/x/tools/cmd/goimports@v0.1.0 &&         go install github.com/onsi/ginkgo/ginkgo@v1.16.1 &&         go install github.com/golang/mock/mockgen@v1.6.0 &&         go install github.com/vektra/mockery/v2@v2.9.6 &&         go install gotest.tools/gotestsum@v1.6.3 &&         go install github.com/axw/gocov/gocov@latest &&         go install github.com/AlekSi/gocov-xml@latest": while running runtime: exit status 1
```