### PR TITLE
Replace mirror to vault, enabling baseurl

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -15,6 +15,10 @@ RUN mkdir $ASSETS_DIR && chmod 775 $ASSETS_DIR
 VOLUME $ASSETS_DIR
 ENV ASSETS_DIR=$ASSETS_DIR
 
+# Replace mirror to vault, enabling baseurl
+RUN sed -i 's,mirror.centos.org,vault.centos.org,' /etc/yum.repos.d/CentOS-Stream-*.repo \
+    && sed -i 's,^#baseurl,baseurl,' /etc/yum.repos.d/CentOS-Stream-*.repo
+
 # Install and config libguestfs
 RUN dnf -y install libguestfs-tools coreos-installer skopeo podman && dnf clean all
 ENV LIBGUESTFS_BACKEND=direct


### PR DESCRIPTION
Some tests are [failing](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-appliance-release-4.15-publish/1873536829400027136) because they are using the old [mirrorlist.centos.org](http://mirrorlist.centos.org).

Since this was disabled for some time, to free the tests results we need modify the container repositories to use the archived version [vault.centos.org/](https://vault.centos.org/).