### PR TITLE
Include openshift-install local path on build output

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -95,7 +95,8 @@ func runBuild(cmd *cobra.Command, args []string) {
 	logrus.Infof("Appliance disk image was successfully created in assets directory: %s", applianceDiskImage.File.Filename)
 	logrus.Info()
 	logrus.Infof("Create configuration ISO using: openshift-install agent create config-image")
-	logrus.Infof("Download openshift-install from: %s", installerBinary.URL)
+	logrus.Infof("Copy 'openshift-install' from: %s/%s", envConfig.CacheDir, "openshift-install")
+	logrus.Infof("Download 'openshift-install' from: %s", installerBinary.URL)
 }
 
 func runBuildISO(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
E.g.
```
INFO Appliance disk image was successfully created in assets directory: assets/appliance.raw 
INFO
INFO Create configuration ISO using: openshift-install agent create config-image 
INFO Copy 'openshift-install' from: assets/cache/4.18.0-rc.2-x86_64/openshift-install 
INFO Download 'openshift-install' from: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.0-rc.2/openshift-install-linux.tar.gz 
```