### PR TITLE
MGMT-19633: Add rendezvous-host.env to install ignition

### DIFF
--- a/data/scripts/bin/set-node-zero.sh.template
+++ b/data/scripts/bin/set-node-zero.sh.template
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+rendezvous_host_env="/etc/assisted/rendezvous-host.env"
+source "${rendezvous_host_env}"
+echo "NODE_ZERO_IP: $NODE_ZERO_IP"
+
+is_node_zero() {
+    local is_rendezvous_host
+    is_rendezvous_host=$(ip -j address | jq "[.[].addr_info] | flatten | map(.local==\"$NODE_ZERO_IP\") | any")
+    if [[ "${is_rendezvous_host}" == "true" ]]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+if [[ $(is_node_zero) -eq 1 ]]; then
+    echo "Node 0 IP ${NODE_ZERO_IP} found on this host" 1>&2
+
+    NODE0_PATH=/etc/assisted/node0
+    mkdir -p "$(dirname "${NODE0_PATH}")"
+
+    NODE_ZERO_MAC=$(ip -j address | jq -r ".[] | select(.addr_info | map(select(.local == \"$NODE_ZERO_IP\")) | any).address")
+    echo "MAC Address for Node 0: ${NODE_ZERO_MAC}"
+
+    cat >"${NODE0_PATH}" <<EOF
+# This file exists if the agent-based installer has determined the host is node 0.
+# The host is determined to be node 0 when one of its network interfaces has an 
+# IP address matching NODE_ZERO_IP in /etc/assisted/rendezvous-host.env. 
+# The MAC address of the network interface matching NODE_ZERO_IP is noted below 
+# as BOOTSTRAP_HOST_MAC.
+#
+BOOTSTRAP_HOST_MAC=${NODE_ZERO_MAC}
+EOF
+    echo "Created file ${NODE0_PATH}"
+    echo 'This host (%s) is the rendezvous host.\n' "${NODE_ZERO_IP}"
+else
+    echo 'This host is not the rendezvous host. The rendezvous host is at %s.\n' "${NODE_ZERO_IP}"
+fi

--- a/data/scripts/bin/update-hosts.sh.template
+++ b/data/scripts/bin/update-hosts.sh.template
@@ -24,9 +24,9 @@ curl_assisted_service() {
     curl "${headers[@]}" -X "${method}" "${additional_options[@]}" "${baseURL}${endpoint}"
 }
 
-total_required_nodes=$(( REQUIRED_MASTER_NODES + REQUIRED_WORKER_NODES ))
-
+# Wait for all required hosts to be discovered
 declare host_ids
+total_required_nodes=$(( REQUIRED_MASTER_NODES + REQUIRED_WORKER_NODES ))
 while [[ "${num_of_hosts}" != "${total_required_nodes}" ]]
 do
     echo "Waiting for ${total_required_nodes} required hosts..." 1>&2
@@ -41,7 +41,15 @@ do
     sleep 2
 done
 
+# Set install ignition config
 ignition=$(echo '{{.InstallIgnitionConfig}}' | jq -c --raw-input)
+
+# Set rendezvous-host.env file in the ignition 
+host_env_base64=$(base64 -w 0 /etc/assisted/rendezvous-host.env)
+placeholder_base64=$(echo -n '{{.RendezvousHostEnvPlaceholder}}' | base64)
+ignition="${ignition//$placeholder_base64/$host_env_base64}"
+
+# Update installer-args and ignition for each host
 if [[ -n ${host_ids} ]]; then
     for id in ${host_ids}; do
         args='["--save-partlabel", "agent*"]'

--- a/data/services/install/set-node-zero.service
+++ b/data/services/install/set-node-zero.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Identify node zero
+Wants=network.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/set-node-zero.sh
+Type=oneshot
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/ignition/bootstrap_ignition.go
+++ b/pkg/asset/ignition/bootstrap_ignition.go
@@ -130,7 +130,8 @@ func (i *BootstrapIgnition) Generate(_ context.Context, dependencies asset.Paren
 		applianceConfig.Config.OcpRelease,
 		bootstrapRegistryDataPath,
 		string(installIgnitionConfig),
-		coreosImagePath)
+		coreosImagePath,
+		rendezvousHostEnvPlaceholder)
 	for _, script := range bootstrapScripts {
 		if err = bootstrap.AddStorageFiles(&i.Config,
 			"/usr/local/bin/"+script,

--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -22,24 +22,28 @@ import (
 )
 
 const (
-	InstallIgnitionPath     = "ignition/install/config.ign"
-	baseIgnitionPath        = "ignition/base/config.ign"
-	bootDevice              = "/dev/disk/by-partlabel/boot"
-	bootMountPath           = "/boot"
-	installRegistryDataPath = "/mnt/agentdata/oc-mirror/install"
-	catalogSourcePattern    = "catalogSource-*.yaml"
-	icspFileName            = "imageContentSourcePolicy.yaml"
+	InstallIgnitionPath          = "ignition/install/config.ign"
+	baseIgnitionPath             = "ignition/base/config.ign"
+	bootDevice                   = "/dev/disk/by-partlabel/boot"
+	bootMountPath                = "/boot"
+	installRegistryDataPath      = "/mnt/agentdata/oc-mirror/install"
+	catalogSourcePattern         = "catalogSource-*.yaml"
+	icspFileName                 = "imageContentSourcePolicy.yaml"
+	rendezvousHostEnvFilePath    = "/etc/assisted/rendezvous-host.env"
+	rendezvousHostEnvPlaceholder = "placeholder-content-for-rendezvous-host.env"
 )
 
 var (
 	installServices = []string{
 		"start-local-registry.service",
 		"add-grub-menuitem.service",
+		"set-node-zero.service",
 	}
 
 	installScripts = []string{
 		"setup-local-registry.sh",
 		"add-grub-menuitem.sh",
+		"set-node-zero.sh",
 	}
 
 	corePassHash string
@@ -132,6 +136,11 @@ func (i *InstallIgnition) Generate(_ context.Context, dependencies asset.Parents
 	if err := i.addRecoveryGrubConfigFile(envConfig.TempDir); err != nil {
 		return err
 	}
+
+	// Add a placeholder for rendezvous-host.env file
+	rendezvousHostEnvFile := ignasset.FileFromString(rendezvousHostEnvFilePath,
+		"root", 0644, rendezvousHostEnvPlaceholder)
+	i.Config.Storage.Files = append(i.Config.Storage.Files, rendezvousHostEnvFile)
 
 	logrus.Debug("Successfully generated install ignition")
 

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -81,7 +81,7 @@ func GetPinnedImageSetTemplateData(images, role string) interface{} {
 	}
 }
 
-func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, registryDataPath, installIgnitionConfig, coreosImagePath string) interface{} {
+func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, registryDataPath, installIgnitionConfig, coreosImagePath, rendezvousHostEnvPlaceholder string) interface{} {
 	releaseImageArr := []map[string]any{
 		{
 			"openshift_version": ocpReleaseImage.Version,
@@ -109,16 +109,18 @@ func GetBootstrapIgnitionTemplateData(ocpReleaseImage types.ReleaseImage, regist
 	}
 
 	return struct {
-		IsBootstrapStep       bool
-		InstallIgnitionConfig string
+		IsBootstrapStep              bool
+		InstallIgnitionConfig        string
+		RendezvousHostEnvPlaceholder string
 
 		ReleaseImages, ReleaseImage, OsImages                             string
 		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryImage string
 
 		Partition0, Partition1, Partition2, Partition3 Partition
 	}{
-		IsBootstrapStep:       true,
-		InstallIgnitionConfig: installIgnitionConfig,
+		IsBootstrapStep:              true,
+		InstallIgnitionConfig:        installIgnitionConfig,
+		RendezvousHostEnvPlaceholder: rendezvousHostEnvPlaceholder,
 
 		// Images
 		ReleaseImages: string(releaseImages),


### PR DESCRIPTION
The rendezvous-host.env file is used post installation to determine which host is the rendezvous. For that, set-node-zero service and script were added.