### PR TITLE
MGMT-19870: Fix FIPS kernel arg in grub.cfg

### DIFF
--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -15,17 +15,19 @@ import (
 )
 
 func GetUserCfgTemplateData(grubMenuEntryName string, enableFips bool) interface{} {
-	boolToInt := map[bool]int{true: 1, false: 0}
+	var fipsArg string
+	if enableFips {
+		fipsArg = "fips=1"
+	}
 
 	return struct {
 		GrubTimeout                              int
 		GrubMenuEntryName, RecoveryPartitionName string
-		EnableFips                               int
+		FipsArg                                  string
 	}{
 		GrubTimeout:           consts.GrubTimeout,
-		GrubMenuEntryName:     grubMenuEntryName,
 		RecoveryPartitionName: consts.RecoveryPartitionName,
-		EnableFips:            boolToInt[enableFips],
+		FipsArg:               fipsArg,
 	}
 }
 

--- a/pkg/templates/scripts/grub/user.cfg.template
+++ b/pkg/templates/scripts/grub/user.cfg.template
@@ -1,6 +1,6 @@
 set timeout={{.GrubTimeout}}
 menuentry '{{.GrubMenuEntryName}}' --class gnu-linux --class gnu --class os {
   search --set=root --label {{.RecoveryPartitionName}}
-  linux /images/pxeboot/vmlinuz coreos.liveiso={{.RecoveryPartitionName}} random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ignition.firstboot ignition.platform.id=metal fips={{.EnableFips}}
+  linux /images/pxeboot/vmlinuz coreos.liveiso={{.RecoveryPartitionName}} random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ignition.firstboot ignition.platform.id=metal {{.FipsArg}}
   initrd /images/pxeboot/initrd.img /images/ignition.img
 }


### PR DESCRIPTION
Avoid adding 'fips=0', as it fails on OCP < 4.18