### PR TITLE
Add privileged flag to podman live iso command

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -690,7 +690,7 @@ Use the 'build live-iso' command for generating the ISO:
 ```shell
 export APPLIANCE_IMAGE="quay.io/edge-infrastructure/openshift-appliance"
 export APPLIANCE_ASSETS="/home/test/appliance_assets"
-sudo podman run --rm -it --pull newer --net=host -v $APPLIANCE_ASSETS:/assets:Z $APPLIANCE_IMAGE build live-iso
+sudo podman run --rm -it --pull newer --privileged --net=host -v $APPLIANCE_ASSETS:/assets:Z $APPLIANCE_IMAGE build live-iso
 ```
 
 The result should be an appliance.iso file under `assets` directory.


### PR DESCRIPTION
When attempting to generate the live iso, I kept coming across a fs-overlay error. After some troubleshooting, I determined that it was due to the privileged flag missing.