### PR TITLE
MGMT-20133: Avoid virtual device creation in live ISO mode

### DIFF
--- a/data/scripts/bin/create-virtual-device.sh.template
+++ b/data/scripts/bin/create-virtual-device.sh.template
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "{{.IsLiveISO}}" = "true" ]; then
+    # A virtual device is not needed in Live ISO mode
+    exit 0
+fi
+
 # Create a sparse-raw file for the boot sector
 dd if=/dev/zero of=/tmp/boot.raw bs=1M seek=1 count=0
 


### PR DESCRIPTION
No need for a virtual device (created from the disk image) in live ISO mode.