### PR TITLE
MGMT-20521: Load extra manifests on cluster startup

### DIFF
--- a/data/scripts/bin/update-hosts.sh.template
+++ b/data/scripts/bin/update-hosts.sh.template
@@ -44,6 +44,20 @@ until [[ -n ${cluster_id} ]]; do
 done
 echo "Fetched cluster-id: $cluster_id"
 
+# Load extra manifests, if present.,Required only for the interactive workflow
+if [[ "$WORKFLOW_TYPE" == "install-interactive-disconnected" ]]; then
+    extraManifestsDir="/etc/assisted/extra-manifests"
+    for file in "$extraManifestsDir"/*.yaml "$extraManifestsDir"/*.yml; do
+        [ -e "$file" ] || continue
+
+        filename=$(basename "${file}")
+        encoded_content=$(base64 -w 0 "${file}")
+        echo "Registering extra manifest ${file}"
+        curl_assisted_service "/clusters/${cluster_id}/manifests" \
+                POST -d "{\"folder\": \"openshift\", \"file_name\": \"${filename}\", \"content\": \"${encoded_content}\"}"
+    done
+fi
+
 # Updating hosts can be done before starting the installation
 until [[ $cluster_status == "preparing-for-installation" ]]; do
     cluster_status=$(curl_assisted_service "/clusters/${cluster_id}" | jq -r .status)


### PR DESCRIPTION
This patch fixes the issue of loading the extra manifests generated by the appliance when the cluster is created by the UI. This step is necessary to ensure the correct installation of the selected OLM operators.

Requires https://github.com/openshift/appliance/pull/375