### PR TITLE
NO-ISSUE: Increase the start timeout to 30 min

### DIFF
--- a/data/services/common/start-local-registry.service
+++ b/data/services/common/start-local-registry.service
@@ -13,7 +13,7 @@ ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
 Restart=on-failure
 RestartSec=10
-TimeoutStartSec=500
+TimeoutStartSec=1800
 TimeoutStopSec=300
 
 [Install]


### PR DESCRIPTION
For particularly big ISOs, 8 minutes could not be enough to reassembly the registry_data.iso, and the service will silently fail leaving a corrupted file