### PR TITLE
AGENT-1193: Allow access to release info when self-signed cert is used

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -48,8 +48,8 @@ const (
 	PodmanPull = "podman pull %s"
 
 	// Release
-	templateGetVersion = "oc adm release info %s -o template --template '{{.metadata.version}}'"
-	templateGetDigest  = "oc adm release info %s -o template --template '{{.digest}}'"
+	templateGetVersion = "oc adm release info %s -o template --template '{{.metadata.version}}' --insecure=true"
+	templateGetDigest  = "oc adm release info %s -o template --template '{{.digest}}' --insecure=true"
 )
 
 var (


### PR DESCRIPTION
Adds --insecure=true to "oc adm release" commands when fetching version and digest.

This allows appliance to work with registries that are using self-signed certificates.

The alterative would be to pass the self-signed certificates to the appliance when it is operated within a container and then use the --certificate-authority flag when executing "oc adm release".