### PR TITLE
MGMT-20615: increasing local registry setup timeout to 2.5h

### DIFF
--- a/data/services/common/start-local-registry.service
+++ b/data/services/common/start-local-registry.service
@@ -13,7 +13,7 @@ ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 
 Restart=on-failure
 RestartSec=10
-TimeoutStartSec=1800
+TimeoutStartSec=9000
 TimeoutStopSec=300
 
 [Install]


### PR DESCRIPTION
This patch allows using the ISO on real baremetal server, where the currently experienced amount of time required to reassembly the data ISO (due the BMC streaming) was about 2hrs