### PR TITLE
MGMT-20943: rename internal registry domain

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -243,7 +243,7 @@ After installing the cluster, images should be available for pulling using the i
 To fetch the digest, use skopeo from inside the node.
 E.g.
 ```shell
-skopeo inspect docker://registry.appliance.com:5000/fedora/httpd-24 | jq .Digest
+skopeo inspect docker://registry.appliance.openshift.com:5000/fedora/httpd-24 | jq .Digest
 "sha256:5d98ffbb97ea86633aed7ae2445b9d939e29639a292d3052efb078e72606ba04"
 ```
 ```shell
@@ -460,7 +460,7 @@ rendezvousIP: 192.168.122.100
 apiVersion: v1
 metadata:
   name: appliance
-baseDomain: appliance.com
+baseDomain: example.com
 controlPlane:
   name: master
   replicas: 1
@@ -493,7 +493,7 @@ rendezvousIP: 192.168.122.100
 apiVersion: v1
 metadata:
   name: appliance
-baseDomain: appliance.com
+baseDomain: example.com
 controlPlane:
   name: master
   replicas: 3

--- a/pkg/asset/registry/registriesconf.go
+++ b/pkg/asset/registry/registriesconf.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	RegistryDomain      = "registry.appliance.com"
+	RegistryDomain      = "registry.appliance.openshift.com"
 	RegistryPort        = 5000
 	RegistryPortUpgrade = 5001
 )

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -198,7 +198,7 @@ func (r *release) copyOutputYamls(ocMirrorDir string) error {
 			return err
 		}
 
-		// Replace registry URI with "registry.appliance.com:5000"
+		// Replace localhost with internal registry URI
 		buildRegistryURI := fmt.Sprintf("127.0.0.1:%d", swag.IntValue(r.ApplianceConfig.Config.ImageRegistry.Port))
 		internalRegistryURI := fmt.Sprintf("%s:%d", registry.RegistryDomain, registry.RegistryPort)
 		newYaml := strings.ReplaceAll(string(yamlBytes), buildRegistryURI, internalRegistryURI)


### PR DESCRIPTION
Avoid using 'appliance.com' domain.