### PR TITLE
MGMT-20942: split ISO ignition into two initrd images

### DIFF
--- a/pkg/asset/appliance/appliance_liveiso.go
+++ b/pkg/asset/appliance/appliance_liveiso.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/asset/data"
+	"github.com/openshift/appliance/pkg/asset/ignition"
 	"github.com/openshift/appliance/pkg/asset/recovery"
 	"github.com/openshift/appliance/pkg/consts"
 	"github.com/openshift/appliance/pkg/coreos"
@@ -22,8 +24,10 @@ import (
 )
 
 const (
-	LiveIsoWorkDir = "live-iso"
-	LiveIsoDataDir = "data"
+	LiveIsoWorkDir        = "live-iso"
+	LiveIsoDataDir        = "data"
+	BootstrapImageName    = "/images/bootstrap.img"
+	BootstrapIgnitionPath = "/usr/lib/ignition/base.d/99-bootstrap.ign"
 )
 
 // ApplianceLiveISO is an asset that generates the OpenShift-based appliance.
@@ -40,7 +44,8 @@ func (a *ApplianceLiveISO) Dependencies() []asset.Asset {
 		&config.EnvConfig{},
 		&config.ApplianceConfig{},
 		&data.DataISO{},
-		&recovery.RecoveryISO{},
+		&recovery.BaseISO{},
+		&ignition.RecoveryIgnition{},
 	}
 }
 
@@ -49,11 +54,12 @@ func (a *ApplianceLiveISO) Generate(_ context.Context, dependencies asset.Parent
 	envConfig := &config.EnvConfig{}
 	applianceConfig := &config.ApplianceConfig{}
 	dataISO := &data.DataISO{}
-	recoveryISO := &recovery.RecoveryISO{}
-	dependencies.Get(envConfig, applianceConfig, dataISO, recoveryISO)
+	baseISO := &recovery.BaseISO{}
+	recoveryIgnition := &ignition.RecoveryIgnition{}
+	dependencies.Get(envConfig, applianceConfig, dataISO, baseISO, recoveryIgnition)
 
 	// Build the live ISO
-	if err := a.buildLiveISO(envConfig, applianceConfig); err != nil {
+	if err := a.buildLiveISO(envConfig, applianceConfig, recoveryIgnition); err != nil {
 		return err
 	}
 
@@ -63,7 +69,7 @@ func (a *ApplianceLiveISO) Generate(_ context.Context, dependencies asset.Parent
 		EnvConfig:       envConfig,
 	}
 	c := coreos.NewCoreOS(coreOSConfig)
-	ignitionBytes, err := json.Marshal(recoveryISO.Ignition.Config)
+	ignitionBytes, err := json.Marshal(recoveryIgnition.Unconfigured)
 	if err != nil {
 		logrus.Errorf("Failed to marshal recovery ignition to json: %s", err.Error())
 		return err
@@ -91,7 +97,11 @@ func (a *ApplianceLiveISO) Name() string {
 	return "Appliance live ISO"
 }
 
-func (a *ApplianceLiveISO) buildLiveISO(envConfig *config.EnvConfig, applianceConfig *config.ApplianceConfig) error {
+func (a *ApplianceLiveISO) buildLiveISO(
+	envConfig *config.EnvConfig,
+	applianceConfig *config.ApplianceConfig,
+	recoveryIgnition *ignition.RecoveryIgnition) error {
+
 	// Create work dir
 	workDir, err := os.MkdirTemp(envConfig.TempDir, LiveIsoWorkDir)
 	if err != nil {
@@ -153,6 +163,35 @@ func (a *ApplianceLiveISO) buildLiveISO(envConfig *config.EnvConfig, applianceCo
 	)
 	spinner.FileToMonitor = consts.DeployIsoName
 
+	// Create bootstrap.img file
+	coreOSConfig := coreos.CoreOSConfig{
+		ApplianceConfig: applianceConfig,
+		EnvConfig:       envConfig,
+	}
+	c := coreos.NewCoreOS(coreOSConfig)
+	ignitionBytes, err := json.Marshal(recoveryIgnition.Bootstrap)
+	if err != nil {
+		logrus.Errorf("Failed to marshal recovery ignition to json: %s", err.Error())
+		return log.StopSpinner(spinner, err)
+	}
+	bootstrapImagePath := filepath.Join(workDir, BootstrapImageName)
+	if err := c.WrapIgnition(ignitionBytes, BootstrapIgnitionPath, bootstrapImagePath); err != nil {
+		logrus.Errorf("Failed to create bootstrap image: %s", err.Error())
+		return log.StopSpinner(spinner, err)
+	}
+
+	// Add bootstrap.img to initrd
+	replacement := fmt.Sprintf("$1 $2 %s", BootstrapImageName)
+	grubCfgPath := filepath.Join(workDir, "EFI", "redhat", "grub.cfg")
+	if err := editFile(grubCfgPath, `(?m)^(\s+initrd) (.+| )+$`, replacement); err != nil {
+		return err
+	}
+	replacement = fmt.Sprintf("${1},%s ${2}", BootstrapImageName)
+	isolinuxCfgPath := filepath.Join(workDir, "isolinux", "isolinux.cfg")
+	if err := editFile(isolinuxCfgPath, `(?m)^(\s+append.*initrd=\S+) (.*)$`, replacement); err != nil {
+		return err
+	}
+
 	// Generate live ISO
 	volumeID, err := isoeditor.VolumeIdentifier(coreosIsoPath)
 	if err != nil {
@@ -170,4 +209,20 @@ func (a *ApplianceLiveISO) buildLiveISO(envConfig *config.EnvConfig, applianceCo
 	}
 
 	return log.StopSpinner(spinner, nil)
+}
+
+func editFile(fileName string, reString string, replacement string) error {
+	content, err := os.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(reString)
+	newContent := re.ReplaceAllString(string(content), replacement)
+
+	if err := os.WriteFile(fileName, []byte(newContent), 0600); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/asset/recovery/recovery_iso.go
+++ b/pkg/asset/recovery/recovery_iso.go
@@ -90,7 +90,7 @@ func (a *RecoveryISO) Generate(_ context.Context, dependencies asset.Parents) er
 		EnvConfig:       envConfig,
 	}
 	c := coreos.NewCoreOS(coreOSConfig)
-	ignitionBytes, err := json.Marshal(recoveryIgnition.Config)
+	ignitionBytes, err := json.Marshal(recoveryIgnition.Merged)
 	if err != nil {
 		logrus.Errorf("Failed to marshal recovery ignition to json: %s", err.Error())
 		return log.StopSpinner(spinner, err)

--- a/pkg/coreos/coreos.go
+++ b/pkg/coreos/coreos.go
@@ -1,11 +1,14 @@
 package coreos
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/cavaliercoder/go-cpio"
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/itchyny/gojq"
 	"github.com/openshift/appliance/pkg/asset/config"
@@ -17,6 +20,7 @@ import (
 
 const (
 	templateEmbedIgnition   = "coreos-installer iso ignition embed -f --ignition-file %s %s"
+	templateWrapIgnition    = "coreos-installer pxe ignition wrap --ignition-file %s --output %s"
 	machineOsImageName      = "machine-os-images"
 	coreOsFileName          = "coreos/coreos-%s.iso"
 	coreOsStream            = "coreos/coreos-stream.json"
@@ -29,6 +33,7 @@ type CoreOS interface {
 	DownloadDiskImage() (string, error)
 	DownloadISO() (string, error)
 	EmbedIgnition(ignition []byte, isoPath string) error
+	WrapIgnition(ignition []byte, ignitionPath, imagePath string) error
 	FetchCoreOSStream() (map[string]any, error)
 }
 
@@ -113,6 +118,30 @@ func (c *coreos) EmbedIgnition(ignition []byte, isoPath string) error {
 	return err
 }
 
+func (c *coreos) WrapIgnition(ignition []byte, ignitionPath, imagePath string) error {
+	ignitionImgFile, err := os.OpenFile(imagePath, os.O_CREATE|os.O_RDWR, 0664)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		ignitionImgFile.Close()
+	}()
+
+
+	compressedCpio, err := generateCompressedCPIO(ignition, ignitionPath, 0o100_644)
+	if err != nil {
+		return err
+	}
+
+	_, err = ignitionImgFile.Write(compressedCpio)
+	if err != nil {
+		logrus.Errorf("Failed to write ignition data into %s: %s", ignitionImgFile.Name(), err.Error())
+		return err
+	}
+
+	return nil
+}
+
 func (c *coreos) FetchCoreOSStream() (map[string]any, error) {
 	path, err := c.Release.ExtractFile(machineOsImageName, coreOsStream)
 	if err != nil {
@@ -130,4 +159,39 @@ func (c *coreos) FetchCoreOSStream() (map[string]any, error) {
 	}
 
 	return m, nil
+}
+
+func generateCompressedCPIO(fileContent []byte, filePath string, mode cpio.FileMode) ([]byte, error) {
+	// Run gzip compression
+	compressedBuffer := new(bytes.Buffer)
+	gzipWriter := gzip.NewWriter(compressedBuffer)
+	// Create CPIO archive
+	cpioWriter := cpio.NewWriter(gzipWriter)
+
+	if err := cpioWriter.WriteHeader(&cpio.Header{
+		Name: filePath,
+		Mode: mode,
+		Size: int64(len(fileContent)),
+	}); err != nil {
+		return nil, errors.Wrap(err, "Failed to write CPIO header")
+	}
+	if _, err := cpioWriter.Write(fileContent); err != nil {
+		return nil, errors.Wrap(err, "Failed to write CPIO archive")
+	}
+
+	if err := cpioWriter.Close(); err != nil {
+		return nil, errors.Wrap(err, "Failed to close CPIO archive")
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, errors.Wrap(err, "Failed to gzip ignition config")
+	}
+
+	padSize := (4 - (compressedBuffer.Len() % 4)) % 4
+	for i := 0; i < padSize; i++ {
+		if err := compressedBuffer.WriteByte(0); err != nil {
+			return nil, err
+		}
+	}
+
+	return compressedBuffer.Bytes(), nil
 }


### PR DESCRIPTION
In order to support the disconnected-interactive flow on SaaS, the ignition.img would be overridden by assisted-image-service (with an unconfigured-ignition that includes user values).

Hence, the live-iso now includes two separate initrd images:
* ignition.img: the uncofigured-igntion (generated with --interactive).
* bootstrap.img: includes only logic added by the appliance.

The bootstrap.img contains '/usr/lib/ignition/base.d/99-bootstrap.ign', so it won't get replaced when generating the user-specific ISO on SaaS.