### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9/go-toolse…

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -1,5 +1,5 @@
 # Build appliance
-FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1752083840 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1751538372 AS builder
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/Dockerfile.openshift-appliance-build
+++ b/Dockerfile.openshift-appliance-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1752083840 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1751538372 AS golang
 
 ENV GOFLAGS=""
 

--- a/Dockerfile.openshift-appliance.ds
+++ b/Dockerfile.openshift-appliance.ds
@@ -1,5 +1,5 @@
 # Build appliance
-FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1752083840 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1751538372 AS builder
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download


### PR DESCRIPTION
…t docker tag to v9.6-1752083840"

This reverts commit 1ce43b98670c312b371b954697dc35f799b86e6a.