### PR TITLE
MGMT-21697: fix stopLocalRegistry property persistency

### DIFF
--- a/data/scripts/bin/stop-local-registry.sh.template
+++ b/data/scripts/bin/stop-local-registry.sh.template
@@ -11,7 +11,7 @@ done
 
 # Stop local registry
 echo "Stopping the local registry..."
-sudo systemctl stop start-local-registry.service
+sudo systemctl disable --now start-local-registry.service
 
 # Remove selector label set in 99-(master|worker)-generated-registries
 # This will delete mirror configuration in /etc/containers/registries.conf

--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -45,6 +45,7 @@ var (
 		"set-node-zero.sh",
 		"setup-local-registry-upgrade.sh",
 		"start-cluster-upgrade.sh",
+		"stop-local-registry.sh",
 		"mount-agent-data.sh",
 		"apply-operator-crs.sh",
 	}
@@ -97,7 +98,6 @@ func (i *InstallIgnition) Generate(_ context.Context, dependencies asset.Parents
 
 	if swag.BoolValue(applianceConfig.Config.StopLocalRegistry) {
 		installServices = append(installServices, "stop-local-registry.service")
-		installScripts = append(installScripts, "stop-local-registry.sh")
 	}
 
 	if swag.BoolValue(applianceConfig.Config.CreatePinnedImageSets) && i.isOcpVersionCompatibleWithPinnedImageSet(applianceConfig) {


### PR DESCRIPTION
When enabling the 'stopLocalRegistry' property in ApplianceConfig, the registry should stop post-installation.
This fix ensures it won't start also on reboot.