### PR TITLE
[WIP] NO-ISSUE: Support dev-scripts custom release payloads

### DIFF
--- a/pkg/asset/config/appliance_config.go
+++ b/pkg/asset/config/appliance_config.go
@@ -48,8 +48,8 @@ const (
 	PodmanPull = "podman pull %s"
 
 	// Release
-	templateGetVersion = "oc adm release info %s -o template --template '{{.metadata.version}}'"
-	templateGetDigest  = "oc adm release info %s -o template --template '{{.digest}}'"
+	templateGetVersion = "oc adm release info %s -o template --template '{{.metadata.version}}' --insecure=true"
+	templateGetDigest  = "oc adm release info %s -o template --template '{{.digest}}' --insecure=true"
 )
 
 var (
@@ -379,7 +379,9 @@ func (a *ApplianceConfig) GetRelease() (string, string, error) {
 				return "", "", nil
 			}
 			releaseDigest = strings.Trim(releaseDigest, "'")
-			releaseImage = fmt.Sprintf("%s@%s", strings.Split(releaseImage, ":")[0], releaseDigest)
+			if idx := strings.LastIndex(releaseImage, ":"); idx != -1 {
+				releaseImage = fmt.Sprintf("%s@%s", releaseImage[:idx], releaseDigest)
+			}
 		}
 		logrus.Debugf("Release image: %s", releaseImage)
 	}


### PR DESCRIPTION
The goal of this patch is to allow supporting dev-scripts [custom release payload](https://github.com/openshift-metal3/dev-scripts/blob/master/agent/docs/custom-release.md). This will make it easier to test the appliance workflow locally, in particular during the development of a new feature (where several changes may be present across different repos).