### PR TITLE
AGENT-1353: Remove --interactive flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 	golangci-lint run -v --timeout=20m
 
 test: $(REPORTS)
-	go test -count=1 -cover -coverprofile=$(COVER_PROFILE) ./...
+	go test -v -count=1 -cover -coverprofile=$(COVER_PROFILE) ./...
 	$(MAKE) _coverage
 
 _coverage:

--- a/pkg/asset/ignition/recovery_ignition.go
+++ b/pkg/asset/ignition/recovery_ignition.go
@@ -6,10 +6,12 @@ import (
 
 	configv32 "github.com/coreos/ignition/v2/config/v3_2"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/go-openapi/swag"
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/asset/manifests"
 	"github.com/openshift/appliance/pkg/installer"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -69,6 +71,16 @@ func (i *RecoveryIgnition) Generate(_ context.Context, dependencies asset.Parent
 	unconfiguredIgnition, _, err := configv32.Parse(configBytes)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse un-configured ignition")
+	}
+
+	if swag.BoolValue(installerConfig.ApplianceConfig.Config.EnableInteractiveFlow) {
+		interactiveUIFile := ignition.FileFromString("/etc/assisted/interactive-ui", "root", 0644, "")
+		unconfiguredIgnition.Storage.Files = append(unconfiguredIgnition.Storage.Files, interactiveUIFile)
+
+		// Explicitly disable the load-config-iso service, not required in the OVE flow
+		// (even though disabled by default, the udev rule may require it).
+		noConfigImageFile := ignition.FileFromString("/etc/assisted/no-config-image", "root", 0644, "")
+		unconfiguredIgnition.Storage.Files = append(unconfiguredIgnition.Storage.Files, noConfigImageFile)
 	}
 
 	i.Unconfigured = unconfiguredIgnition

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -84,9 +84,6 @@ func (i *installer) CreateUnconfiguredIgnition() (string, error) {
 	}
 
 	createCmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, openshiftInstallFilePath, i.EnvConfig.TempDir)
-	if swag.BoolValue(i.ApplianceConfig.Config.EnableInteractiveFlow) {
-		createCmd = fmt.Sprintf("%s --interactive", createCmd)
-	}
 	_, err = i.Executer.Execute(createCmd)
 	return filepath.Join(i.EnvConfig.TempDir, unconfiguredIgnitionFileName), err
 }

--- a/pkg/installer/installer_test.go
+++ b/pkg/installer/installer_test.go
@@ -173,34 +173,6 @@ var _ = Describe("Test Installer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res).To(Equal(filepath.Join(tmpDir, unconfiguredIgnitionFileName)))
 	})
-
-	It("CreateUnconfiguredIgnition - interactive flow enabled", func() {
-		tmpDir, err := filepath.Abs("")
-		Expect(err).ToNot(HaveOccurred())
-		cmd := fmt.Sprintf(templateUnconfiguredIgnitionBinary, installerBinaryName, tmpDir)
-		cmd = fmt.Sprintf("%s --interactive", cmd)
-		mockExecuter.EXPECT().Execute(cmd).Return("", nil).Times(1)
-
-		installerConfig := InstallerConfig{
-			Executer: mockExecuter,
-			Release:  mockRelease,
-			EnvConfig: &config.EnvConfig{
-				DebugBaseIgnition: false,
-				TempDir:           tmpDir,
-			},
-			ApplianceConfig: &config.ApplianceConfig{
-				Config: &types.ApplianceConfig{
-					EnableInteractiveFlow: swag.Bool(true),
-				},
-			},
-		}
-		testInstaller = NewInstaller(installerConfig)
-		mockRelease.EXPECT().ExtractCommand(installerBinaryName, installerConfig.EnvConfig.CacheDir).Return("", nil).Times(1)
-
-		res, err := testInstaller.CreateUnconfiguredIgnition()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(Equal(filepath.Join(tmpDir, unconfiguredIgnitionFileName)))
-	})
 })
 
 func TestInstaller(t *testing.T) {


### PR DESCRIPTION
### Migration from flag-based to file-based configuration.

This change provides a more robust and flexible mechanism for enabling interactive installation flows. The sentinel file approach allows the system to detect interactive mode by checking for file presence rather than parsing command-line arguments, which is cleaner and more maintainable.

###   Key Changes:
  - Remove `--interactive` flag from openshift-install command invocation
  - Create `/etc/assisted/interactive-ui` sentinel file when `EnableInteractiveFlow`
    is `true` to signal interactive UI mode
  - Create `/etc/assisted/no-config-image` to explicitly disable load-config-iso
    service
  - Add verbose flag to test runs for improved debugging

  This change aligns with the installer simplification in
  openshift/installer#10020, where `AgentWorkflowTypeInstallInteractiveDisconnected`
  workflow is removed. OVE configuration is now fully embedded in the
  appliance's system ignition rather than passed via command-line flags.

  🤖 PR description generated with [Claude Code](https://claude.com/claude-code)
