### PR TITLE
AGENT-1426: Use localhost for registry domain in interactive flow

### DIFF
--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -127,6 +127,7 @@ func (i *InstallIgnition) Generate(dependencies asset.Parents) error {
 	// Create install template data
 	templateData := templates.GetInstallIgnitionTemplateData(
 		envConfig.IsLiveISO,
+		swag.BoolValue(applianceConfig.Config.EnableInteractiveFlow),
 		corePassHash,
 		registry.RegistryCacheDigestKey(registryImageURI))
 

--- a/pkg/asset/registry/registriesconf_test.go
+++ b/pkg/asset/registry/registriesconf_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/appliance/pkg/asset/config"
+	"github.com/openshift/appliance/pkg/types"
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -21,7 +22,7 @@ var _ = Describe("Test RegistriesConf", func() {
 		fakeFileSystem = fstest.MapFS{}
 		deps = asset.Parents{}
 
-		deps.Add(&config.EnvConfig{}, &config.ApplianceConfig{})
+		deps.Add(&config.EnvConfig{}, &config.ApplianceConfig{Config: &types.ApplianceConfig{}})
 		r = RegistriesConf{
 			fSys: fakeFileSystem,
 		}

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -113,7 +113,7 @@ func GetBootstrapIgnitionTemplateData(isLiveISO, enableInteractiveFlow bool, ocp
 		InstallIgnitionConfig        string
 		RendezvousHostEnvPlaceholder string
 
-		ReleaseImages, ReleaseImage, OsImages                             string
+		ReleaseImages, ReleaseImage, OsImages                              string
 		RegistryDomain, RegistryFilePath, RegistryDigestKey, RegistryImage string
 
 		Partition0, Partition1, Partition2, Partition3 Partition
@@ -130,10 +130,17 @@ func GetBootstrapIgnitionTemplateData(isLiveISO, enableInteractiveFlow bool, ocp
 		OsImages:      string(osImages),
 
 		// Registry
-		RegistryDomain:      registry.RegistryDomain,
-		RegistryFilePath:    consts.RegistryFilePath,
-		RegistryDigestKey:   registryDigestKey,
-		RegistryImage:       consts.RegistryImage,
+		RegistryDomain:    registry.RegistryDomain,
+		RegistryFilePath:  consts.RegistryFilePath,
+		RegistryDigestKey: registryDigestKey,
+		RegistryImage:     consts.RegistryImage,
+	}
+
+	// If interactive flow is enabled, use localhost as registry domain, otherwise use the default registry domain
+	if enableInteractiveFlow {
+		data.RegistryDomain = "localhost"
+	} else {
+		data.RegistryDomain = registry.RegistryDomain
 	}
 
 	// Fetch base image partitions (Disk image mode)
@@ -153,19 +160,27 @@ func GetBootstrapIgnitionTemplateData(isLiveISO, enableInteractiveFlow bool, ocp
 	return data
 }
 
-func GetInstallIgnitionTemplateData(isLiveISO bool, corePassHash, registryDigestKey string) interface{} {
+func GetInstallIgnitionTemplateData(isLiveISO, enableInteractiveFlow bool, corePassHash, registryDigestKey string) interface{} {
+	// If interactive flow is enabled, use localhost as registry domain, otherwise use the default registry domain
+	var registryDomain string
+	if enableInteractiveFlow {
+		registryDomain = "localhost"
+	} else {
+		registryDomain = registry.RegistryDomain
+	}
+
 	return struct {
 		IsBootstrapStep bool
 		IsLiveISO       bool
 
 		RegistryDataPath, RegistryDomain, RegistryFilePath, RegistryDigestKey, RegistryImage string
-		CorePassHash, GrubCfgFilePath, UserCfgFilePath                                        string
+		CorePassHash, GrubCfgFilePath, UserCfgFilePath                                       string
 	}{
 		IsBootstrapStep: false,
 		IsLiveISO:       isLiveISO,
 
 		// Registry
-		RegistryDomain:    registry.RegistryDomain,
+		RegistryDomain:    registryDomain,
 		RegistryFilePath:  consts.RegistryFilePath,
 		RegistryDigestKey: registryDigestKey,
 		RegistryImage:     consts.RegistryImage,


### PR DESCRIPTION
When EnableInteractiveFlow is enabled, configure registry mirrors and oc-mirror output to use localhost instead of the default registry domain. This is needed to avoid any suprious entries in registries.conf file.

Changes:
- Update generateRegistries to accept enableInteractiveFlow parameter
- Use localhost when interactive flow is enabled for registry mirrors
- Update copyOutputYamls to use localhost registry domain in interactive flow
- Add swag import for boolean value handling