### PR TITLE
Bump OpenShift client and oc-mirror to 4.21.0

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -27,11 +27,11 @@ RUN DNF=$(command -v microdnf || command -v dnf) && \
 ENV LIBGUESTFS_BACKEND=direct
 
 # Download oc
-RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/openshift-client-linux.tar.gz || true
+RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.0/openshift-client-linux.tar.gz || true
 RUN tar xvzf /tmp/openshift-client-linux.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc
 
 # Download oc-mirror
-RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/oc-mirror.tar.gz || true
+RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.0/oc-mirror.tar.gz || true
 RUN tar xvzf /tmp/oc-mirror.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
 
 # Copy openshift-appliance binary

--- a/pkg/asset/ignition/bootstrap_ignition.go
+++ b/pkg/asset/ignition/bootstrap_ignition.go
@@ -113,7 +113,7 @@ func (i *BootstrapIgnition) Generate(dependencies asset.Parents) error {
 	// Determine if we're using the OCP registry (for the podman run command)
 	useOcpRegistry := reg.ShouldUseOcpRegistry(envConfig, applianceConfig)
 	if useOcpRegistry {
-		logrus.Info("BootstrapIgnition will use OCP docker-registry image")
+		logrus.Debug("BootstrapIgnition will use OCP docker-registry image")
 	}
 
 	i.Config = igntypes.Config{

--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -80,7 +80,7 @@ func (i *InstallIgnition) Generate(dependencies asset.Parents) error {
 	// Determine if we're using the OCP registry (for the podman run command)
 	useOcpRegistry := registry.ShouldUseOcpRegistry(envConfig, applianceConfig)
 	if useOcpRegistry {
-		logrus.Info("InstallIgnition will use OCP docker-registry image")
+		logrus.Debug("InstallIgnition will use OCP docker-registry image")
 	}
 
 	i.Config = igntypes.Config{

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -35,9 +35,9 @@ const (
 	templateGetImage     = "oc adm release info --image-for=%s --insecure=%t %s"
 	templateExtractCmd   = "oc adm release extract --command=%s --to=%s %s"
 	templateImageExtract = "oc image extract --path %s:%s --confirm %s"
-	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5"
+	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5 --ignore-release-signature"
 	// ocMirrorDryRun is the command template for running oc mirror in dry-run mode to generate mapping.txt
-	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --dry-run"
+	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --ignore-release-signature --dry-run"
 )
 
 // Release is the interface to use the oc command to the get image info


### PR DESCRIPTION
- Bump openshift-client-linux and oc-mirror in Dockerfile to 4.21.0.
- Add --ignore-release-signature to oc mirror and oc mirror dry-run commands in release.go.

Note: oc-mirror 4.21 fails when mirroring CI/unsigned release images without --ignore-release-signature (GenerateReleaseSignatures error); both changes are required for 4.21 to work with such images.