### PR TITLE
OCPBUGS-81505: Fix update-hosts.sh crash when no hosts registered yet

### DIFF
--- a/data/scripts/bin/update-hosts.sh.template
+++ b/data/scripts/bin/update-hosts.sh.template
@@ -62,6 +62,14 @@ fi
 until [[ $cluster_status == "preparing-for-installation" ]]; do
     cluster_status=$(curl_assisted_service "/clusters/${cluster_id}" | jq -r .status)
 
+    # Wait until cluster is ready (all hosts registered and validated) before patching.
+    # This avoids querying the hosts API before any hosts have registered, which causes
+    # assisted-service to return an error object instead of an empty array.
+    if [[ $cluster_status != "ready" && $cluster_status != "preparing-for-installation" ]]; then
+        sleep 1
+        continue
+    fi
+
     # Update ignition for each host
     host_ids=$(curl_assisted_service "/infra-envs/${INFRA_ENV_ID}/hosts" | jq -r .[].id)
     if [[ -z ${host_ids} ]]; then


### PR DESCRIPTION
When update-hosts.service starts, it may call the infra-envs hosts API before any hosts have registered with assisted-service. In this race condition, assisted-service returns an error JSON object instead of an empty array, causing 'jq -r .[].id' to fail with "Cannot index string with string 'id'". With set -e, this kills the script before it can patch the install ignition on any host.

Fix by skipping the hosts API call until the cluster reaches 'ready' status, which guarantees all hosts have registered and been validated. Patching also continues through 'preparing-for-installation' to ensure all hosts are updated before disk installation begins.

Assisted-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>