### PR TITLE
AGENT-1475: add the ocp release digest annotation to the bundle image (followup)

### DIFF
--- a/pkg/asset/data/data_iso.go
+++ b/pkg/asset/data/data_iso.go
@@ -64,7 +64,7 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 		return err
 	}
 
-	_, releaseVersion, err := applianceConfig.GetRelease()
+	releaseImage, releaseVersion, err := applianceConfig.GetRelease()
 	if err != nil {
 		return err
 	}
@@ -118,6 +118,7 @@ func (a *DataISO) Generate(dependencies asset.Parents) error {
 	bundle := releasebundle.NewBundle(releasebundle.BundleConfig{
 		Port:           swag.IntValue(applianceConfig.Config.ImageRegistry.Port),
 		ReleaseVersion: releaseVersion,
+		ReleaseImage:   releaseImage,
 	})
 	if err = bundle.Push(); err != nil {
 		return log.StopSpinner(spinner, err)

--- a/pkg/releasebundle/releasebundle.go
+++ b/pkg/releasebundle/releasebundle.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openshift/appliance/pkg/executer"
 	"github.com/pkg/errors"
 )
 
 const (
-	bundleBuildCmd = "podman build -f %s -t %s %s"
+	bundleBuildCmd = "podman build --annotation 'com.openshift.release-image-digest=%s' -f %s -t %s %s"
 	bundlePushCmd  = "podman push --tls-verify=false %s"
 )
 
@@ -18,6 +19,7 @@ type BundleConfig struct {
 	Executer       executer.Executer
 	Port           int
 	ReleaseVersion string
+	ReleaseImage   string
 }
 
 type Bundle struct {
@@ -31,15 +33,28 @@ func NewBundle(config BundleConfig) *Bundle {
 	return &Bundle{BundleConfig: config}
 }
 
+func (b *Bundle) getReleaseDigest() (string, error) {
+	parts := strings.Split(b.ReleaseImage, "@")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("cannot extract digest from release image %s", b.ReleaseImage)
+	}
+	return parts[1], nil
+}
+
 func (b *Bundle) Push() error {
 	dockerfilePath, ctx, err := resolveDockerfile()
 	if err != nil {
 		return err
 	}
 
+	releaseDigest, err := b.getReleaseDigest()
+	if err != nil {
+		return err
+	}
+
 	tag := Tag(b.ReleaseVersion)
 	imageRef := registryImageRef(b.Port, tag)
-	buildCmd := fmt.Sprintf(bundleBuildCmd, dockerfilePath, imageRef, ctx)
+	buildCmd := fmt.Sprintf(bundleBuildCmd, releaseDigest, dockerfilePath, imageRef, ctx)
 	if _, err := b.Executer.Execute(buildCmd); err != nil {
 		return errors.Wrap(err, "build release bundle image")
 	}

--- a/pkg/releasebundle/releasebundle_test.go
+++ b/pkg/releasebundle/releasebundle_test.go
@@ -49,13 +49,15 @@ func TestBundlePush(t *testing.T) {
 	const port = 5005
 	tag := Tag("4.22.0-0.ci-2026-03-23-012741")
 	imageRef := registryImageRef(port, tag)
-	mockExec.EXPECT().Execute("podman build -f bundle/Dockerfile.bundle -t " + imageRef + " bundle").Return("", nil)
-	mockExec.EXPECT().Execute("podman push --tls-verify=false " + imageRef).Return("", nil)
+	relDigest := "sha256:58bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0388"
+	mockExec.EXPECT().Execute("podman build --annotation 'com.openshift.release-image-digest="+relDigest+"' -f bundle/Dockerfile.bundle -t "+imageRef+" bundle").Return("", nil)
+	mockExec.EXPECT().Execute("podman push --tls-verify=false "+imageRef).Return("", nil)
 
 	b := NewBundle(BundleConfig{
 		Executer:       mockExec,
 		Port:           port,
 		ReleaseVersion: "4.22.0-0.ci-2026-03-23-012741",
+		ReleaseImage:   "registry.ci.openshift.org/ocp/release@" + relDigest,
 	})
 
 	if err := b.Push(); err != nil {
@@ -74,12 +76,14 @@ func TestBundlePushBuildFails(t *testing.T) {
 	const port = 5005
 	tag := Tag("4.20.5-x86_64")
 	imageRef := registryImageRef(port, tag)
-	mockExec.EXPECT().Execute("podman build -f bundle/Dockerfile.bundle -t " + imageRef + " bundle").Return("", errors.New("boom"))
+	relDigest := "sha256:58bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0388"
+	mockExec.EXPECT().Execute("podman build --annotation 'com.openshift.release-image-digest="+relDigest+"' -f bundle/Dockerfile.bundle -t "+imageRef+" bundle").Return("", errors.New("boom"))
 
 	b := NewBundle(BundleConfig{
 		Executer:       mockExec,
 		Port:           port,
 		ReleaseVersion: "4.20.5-x86_64",
+		ReleaseImage:   "registry.ci.openshift.org/ocp/release@" + relDigest,
 	})
 
 	err := b.Push()
@@ -103,13 +107,15 @@ func TestBundlePushPushFails(t *testing.T) {
 	const port = 5005
 	tag := Tag("4.20.5-x86_64")
 	imageRef := registryImageRef(port, tag)
-	mockExec.EXPECT().Execute("podman build -f bundle/Dockerfile.bundle -t " + imageRef + " bundle").Return("", nil)
-	mockExec.EXPECT().Execute("podman push --tls-verify=false " + imageRef).Return("", errors.New("push boom"))
+	relDigest := "sha256:58bdf24405449be5c78a1f27a7b64fc9ee980e4bc3c9b169e8b3da08e50e0388"
+	mockExec.EXPECT().Execute("podman build --annotation 'com.openshift.release-image-digest="+relDigest+"' -f bundle/Dockerfile.bundle -t "+imageRef+" bundle").Return("", nil)
+	mockExec.EXPECT().Execute("podman push --tls-verify=false "+imageRef).Return("", errors.New("push boom"))
 
 	b := NewBundle(BundleConfig{
 		Executer:       mockExec,
 		Port:           port,
 		ReleaseVersion: "4.20.5-x86_64",
+		ReleaseImage:   "registry.ci.openshift.org/ocp/release@" + relDigest,
 	})
 
 	err := b.Push()


### PR DESCRIPTION
This patch adds the OCP release image digest as an annotation on the release bundle image.
This will allow the new MCD IRI manager (see https://github.com/openshift/machine-config-operator/pull/5807) to retrieve which OCP release digest is related to a given release bundle image while updating the MCN status, by simply getting the release image manifest (so no need of additional complex operations to retrieve such relationship).