### PR TITLE
Bump maximum supported OCP version to 4.22

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	MaxOcpVersion = "4.20" // Latest supported version (update on each release)
+	MaxOcpVersion = "4.22" // Latest supported version (update on each release)
 	MinOcpVersion = "4.14"
 
 	// user.cfg template


### PR DESCRIPTION
Raise MaxOcpVersion so appliance builds and validation accept OpenShift 4.22 as the latest supported release.