### PR TITLE
OCPBUGS-84716: Bump oc/oc-mirror to 4.21.0

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -27,11 +27,11 @@ RUN DNF=$(command -v microdnf || command -v dnf) && \
 ENV LIBGUESTFS_BACKEND=direct
 
 # Download oc
-RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/openshift-client-linux.tar.gz || true
+RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.0/openshift-client-linux.tar.gz || true
 RUN tar xvzf /tmp/openshift-client-linux.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc
 
 # Download oc-mirror
-RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.18.5/oc-mirror.tar.gz || true
+RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.21.0/oc-mirror.tar.gz || true
 RUN tar xvzf /tmp/oc-mirror.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
 
 # Copy openshift-appliance binary


### PR DESCRIPTION
Bump openshift-client-linux and oc-mirror in Dockerfile to 4.21.0.