### PR TITLE
OCPBUGS-84696: Stable releases should be allowed to generate signature-configmap.yaml

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -35,9 +35,9 @@ const (
 	templateGetImage     = "oc adm release info --image-for=%s --insecure=%t %s"
 	templateExtractCmd   = "oc adm release extract --command=%s --to=%s %s"
 	templateImageExtract = "oc image extract --path %s:%s --confirm %s"
-	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5 --ignore-release-signature"
+	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5"
 	// ocMirrorDryRun is the command template for running oc mirror in dry-run mode to generate mapping.txt
-	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --ignore-release-signature --dry-run"
+	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --dry-run"
 )
 
 // Release is the interface to use the oc command to the get image info


### PR DESCRIPTION
Stable releases should be allowed to generate signature-configmap.yaml