### PR TITLE
OCPBUGS-84892: Update MaxOcpVersion to 4.21

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	MaxOcpVersion = "4.19" // Latest supported version (update on each release)
+	MaxOcpVersion = "4.21" // Latest supported version (update on each release)
 	MinOcpVersion = "4.14"
 
 	// user.cfg template


### PR DESCRIPTION
release-4.21 branch has MaxOcpVersion="4.19" instead of "4.21" causing fallback to wrong minor version