### PR TITLE
Update MaxOcpVersion to 4.23

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	MaxOcpVersion = "4.22" // Latest supported version (update on each release)
+	MaxOcpVersion = "4.23" // Latest supported version (update on each release)
 	MinOcpVersion = "4.14"
 
 	// user.cfg template


### PR DESCRIPTION
release-4.23 branch had MaxOcpVersion="4.22" instead of "4.23" causing fallback to wrong minor version