### PR TITLE
Update MaxOcpVersion

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,7 +1,7 @@
 package consts
 
 const (
-	MaxOcpVersion = "4.22" // Latest supported version (update on each release)
+	MaxOcpVersion = "5.0" // Latest supported version (update on each release)
 	MinOcpVersion = "4.14"
 
 	// user.cfg template


### PR DESCRIPTION
The release-4.23, master and release-5.0 branch has MaxOcpVersion="4.22" instead of "5.0" causing fallback to wrong minor version. As of today, release-4.23 and release-5.0 branches are kept up to date with master as  release-4.23 == release-5.0