### PR TITLE
OCPBUGS-84896: NoRegistryClusterInstall fails due to invalid InternalReleaseImage name

### DIFF
--- a/pkg/asset/ignition/interactiveflow_ignition.go
+++ b/pkg/asset/ignition/interactiveflow_ignition.go
@@ -11,11 +11,13 @@ import (
 // igntion files required to support the interactive flow.
 type interactiveFlowIgnition struct {
 	releaseVersion string
+	arch           string
 }
 
-func NewInteractiveFlowIgnition(releaseVersion string) *interactiveFlowIgnition {
+func NewInteractiveFlowIgnition(releaseVersion, arch string) *interactiveFlowIgnition {
 	return &interactiveFlowIgnition{
 		releaseVersion: releaseVersion,
+		arch:           arch,
 	}
 }
 
@@ -35,8 +37,13 @@ func (i *interactiveFlowIgnition) appendControlFiles(ign *igntypes.Config) {
 }
 
 func (i *interactiveFlowIgnition) appendInternalReleaseImageManifest(ign *igntypes.Config) {
-	// Trim ocp bundle names longer than 64 chars.
 	ocpBundleStr := fmt.Sprintf("ocp-release-bundle-%s", i.releaseVersion)
+
+	// For non-CI/nightly builds (stable, RC, DevPreview), append architecture suffix
+	if i.arch != "" {
+		ocpBundleStr = fmt.Sprintf("%s-%s", ocpBundleStr, i.arch)
+	}
+	// Trim ocp bundle names longer than 64 chars.
 	if len(ocpBundleStr) > 64 {
 		ocpBundleStr = ocpBundleStr[:64]
 	}

--- a/pkg/asset/ignition/interactiveflow_ignition_test.go
+++ b/pkg/asset/ignition/interactiveflow_ignition_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Test InteractiveFlow Ignition", func() {
 	})
 
 	It("Default additional files", func() {
-		i := *NewInteractiveFlowIgnition("4.20.5-x86_64")
+		i := *NewInteractiveFlowIgnition("4.20.5", "")
 		i.AppendToIgnition(ign)
 		Expect(ign.Storage.Files).To(HaveLen(3))
 
@@ -48,8 +48,8 @@ var _ = Describe("Test InteractiveFlow Ignition", func() {
 	})
 
 	DescribeTable("Release names",
-		func(releaseVersion string, expectedReleaseStr string) {
-			i := *NewInteractiveFlowIgnition(releaseVersion)
+		func(releaseVersion, arch string, expectedReleaseStr string) {
+			i := *NewInteractiveFlowIgnition(releaseVersion, arch)
 			i.AppendToIgnition(ign)
 
 			data, err := ignitionGetFileData(ign, "/etc/assisted/extra-manifests/internalreleaseimage.yaml")
@@ -68,12 +68,12 @@ var _ = Describe("Test InteractiveFlow Ignition", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(iri.Spec.Releases[0].Name).To(Equal(expectedReleaseStr))
 		},
-		Entry("valid release name", "4.21.0-ec.3-x86_64", "ocp-release-bundle-4.21.0-ec.3-x86_64"),
-		Entry("valid release name", "4.20.5-x86_64", "ocp-release-bundle-4.20.5-x86_64"),
-		Entry("valid release name", "4.14.0-0.nightly-2025-11-23-025204", "ocp-release-bundle-4.14.0-0.nightly-2025-11-23-025204"),
-		Entry("valid release name", "4.21.0-ec.2-s390x", "ocp-release-bundle-4.21.0-ec.2-s390x"),
-		Entry("valid release name", "4.15.0-0.ci-2025-11-22-162639", "ocp-release-bundle-4.15.0-0.ci-2025-11-22-162639"),
-		Entry("trim releases longer than 64 chars", "4.22.0-0.ci-2026-02-09-204741-test-ci-op-phx0mrh8-latest", "ocp-release-bundle-4.22.0-0.ci-2026-02-09-204741-test-ci-op-phx0"),
+		Entry("stable release with arch suffix", "4.21.0-ec.3", "x86_64", "ocp-release-bundle-4.21.0-ec.3-x86_64"),
+		Entry("stable release with arch suffix", "4.20.5", "x86_64", "ocp-release-bundle-4.20.5-x86_64"),
+		Entry("nightly release without arch suffix", "4.14.0-0.nightly-2025-11-23-025204", "", "ocp-release-bundle-4.14.0-0.nightly-2025-11-23-025204"),
+		Entry("stable release with arch suffix", "4.21.0-ec.2", "s390x", "ocp-release-bundle-4.21.0-ec.2-s390x"),
+		Entry("CI release without arch suffix", "4.15.0-0.ci-2025-11-22-162639", "", "ocp-release-bundle-4.15.0-0.ci-2025-11-22-162639"),
+		Entry("trim releases longer than 64 chars", "4.22.0-0.ci-2026-02-09-204741-test-ci-op-phx0mrh8-latest", "", "ocp-release-bundle-4.22.0-0.ci-2026-02-09-204741-test-ci-op-phx0"),
 	)
 })
 
@@ -89,7 +89,7 @@ var _ = Describe("RecoveryIgnition interactive flow placement", func() {
 	It("places interactive flow files in Bootstrap and Merged, not in Unconfigured", func() {
 		unconfigured := types.Config{Storage: types.Storage{}}
 		bootstrap := types.Config{Storage: types.Storage{}}
-		NewInteractiveFlowIgnition("4.20.5-x86_64").AppendToIgnition(&bootstrap)
+		NewInteractiveFlowIgnition("4.20.5", "").AppendToIgnition(&bootstrap)
 
 		for _, p := range interactiveFlowPaths {
 			Expect(hasStorageFile(unconfigured, p)).To(BeFalse(), "interactive flow file %q should not be in Unconfigured", p)

--- a/pkg/asset/ignition/recovery_ignition.go
+++ b/pkg/asset/ignition/recovery_ignition.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/asset/manifests"
 	"github.com/openshift/appliance/pkg/installer"
+	"github.com/openshift/appliance/pkg/release"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -79,7 +80,26 @@ func (i *RecoveryIgnition) Generate(_ context.Context, dependencies asset.Parent
 		if err != nil {
 			return err
 		}
-		ifi := NewInteractiveFlowIgnition(releaseVersion)
+
+		releaseConfig := release.ReleaseConfig{
+			ApplianceConfig: applianceConfig,
+		}
+		rel := release.NewRelease(releaseConfig)
+
+		isStable, err := rel.IsStableRelease()
+		if err != nil {
+			return errors.Wrapf(err, "failed to determine if release is stable")
+		}
+
+		arch := ""
+		if isStable {
+			arch, err = rel.GetArchitecture()
+			if err != nil {
+				return errors.Wrapf(err, "failed to get architecture from release metadata")
+			}
+		}
+
+		ifi := NewInteractiveFlowIgnition(releaseVersion, arch)
 		ifi.AppendToIgnition(&bootstrapIgnition.Config)
 	}
 

--- a/pkg/release/mock_release.go
+++ b/pkg/release/mock_release.go
@@ -63,6 +63,21 @@ func (mr *MockReleaseMockRecorder) ExtractFile(image, filename interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFile", reflect.TypeOf((*MockRelease)(nil).ExtractFile), image, filename)
 }
 
+// GetArchitecture mocks base method.
+func (m *MockRelease) GetArchitecture() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArchitecture")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetArchitecture indicates an expected call of GetArchitecture.
+func (mr *MockReleaseMockRecorder) GetArchitecture() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchitecture", reflect.TypeOf((*MockRelease)(nil).GetArchitecture))
+}
+
 // GetImageFromRelease mocks base method.
 func (m *MockRelease) GetImageFromRelease(imageName string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/stream-metadata-go/arch"
 	"github.com/go-openapi/swag"
 	"github.com/openconfig/goyang/pkg/indent"
 	"github.com/openshift/appliance/pkg/asset/config"
@@ -56,6 +57,7 @@ type Release interface {
 	MirrorInstallImages() error
 	GetImageFromRelease(imageName string) (string, error)
 	ExtractCommand(command string, dest string) (string, error)
+	GetArchitecture() (string, error)
 	IsStableRelease() (bool, error)
 }
 
@@ -68,11 +70,15 @@ type ReleaseConfig struct {
 
 type release struct {
 	ReleaseConfig
+	arch    *string
 	version *string
 }
 
 // releaseInfo represents the structure of oc adm release info output
 type releaseInfo struct {
+	Config struct {
+		Architecture string `json:"architecture"`
+	} `json:"config"`
 	Metadata struct {
 		Version string `json:"version"`
 	} `json:"metadata"`
@@ -226,6 +232,7 @@ func (r *release) copyOutputYamls(ocMirrorDir string) error {
 	if err != nil {
 		return err
 	}
+	// Iterate over all yaml files and replace the localhost with the internal registry URI
 	for _, yamlPath := range yamlPaths {
 		logrus.Debugf("Copying ymals from oc-mirror output: %s", yamlPath)
 		yamlBytes, err := r.OSInterface.ReadFile(yamlPath)
@@ -286,16 +293,16 @@ func (r *release) MirrorInstallImages() error {
 	)
 }
 
-// getMetadata fetches release metadata (version) if not already cached.
-// This lazy loading approach avoids redundant oc adm release info calls by fetching
-// version in a single JSON command execution.
+// getMetadata fetches release metadata (architecture and version) if not already cached.
+// This lazy loading approach avoids redundant oc adm release info calls by fetching both
+// architecture and version in a single JSON command execution.
 func (r *release) getMetadata() error {
-	if r.version != nil {
+	if r.arch != nil && r.version != nil {
 		return nil
 	}
 
 	cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(r.ApplianceConfig.Config.OcpRelease.URL))
-	logrus.Debugf("Fetching version from OCP release (%s)", cmd)
+	logrus.Debugf("Fetching architecture and version from OCP release (%s)", cmd)
 
 	output, err := r.execute(cmd)
 	if err != nil {
@@ -307,11 +314,27 @@ func (r *release) getMetadata() error {
 		return fmt.Errorf("failed to parse release metadata JSON: %w", err)
 	}
 
+	architecture := metadata.Config.Architecture
 	version := metadata.Metadata.Version
 
+	// Convert to RpmArch if architecture is defined (amd64 -> x86_64, arm64 -> aarch64)
+	if architecture != "" {
+		architecture = arch.RpmArch(architecture)
+	}
+
+	r.arch = &architecture
 	r.version = &version
 
 	return nil
+}
+
+// GetArchitecture retrieves the CPU architecture from the release metadata.
+// Uses lazy loading to avoid redundant external calls.
+func (r *release) GetArchitecture() (string, error) {
+	if err := r.getMetadata(); err != nil {
+		return "", err
+	}
+	return *r.arch, nil
 }
 
 // IsStableRelease checks if the release is a stable/production release by validating the version string.

--- a/pkg/release/release_test.go
+++ b/pkg/release/release_test.go
@@ -231,11 +231,43 @@ var _ = Describe("Test Release", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	Context("GetArchitecture", func() {
+		It("should convert amd64 to x86_64 with digest URL", func() {
+			applianceConfig.Config.OcpRelease.URL = swag.String("quay.io/openshift-release-dev/ocp-release@sha256:809c037c016c7c0cbc83ce459ed344a55d65fa6cc0d3aa4d51e9a2d9d0cf7ffa")
+			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
+			jsonOutput := `{"config":{"architecture":"amd64"},"metadata":{"version":"4.21.0"}}`
+			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
+
+			arch, err := testRelease.GetArchitecture()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arch).To(Equal("x86_64"))
+		})
+
+		It("should convert amd64 to x86_64 with tag URL", func() {
+			applianceConfig.Config.OcpRelease.URL = swag.String("quay.io/openshift-release-dev/ocp-release:4.21.12-x86_64")
+			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
+			jsonOutput := `{"config":{"architecture":"amd64"},"metadata":{"version":"4.21.12"}}`
+			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
+
+			arch, err := testRelease.GetArchitecture()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(arch).To(Equal("x86_64"))
+		})
+
+		It("should handle error when getting architecture", func() {
+			applianceConfig.Config.OcpRelease.URL = swag.String("invalid-url")
+			mockExecuter.EXPECT().Execute(gomock.Any()).Return("", errors.New("failed to get architecture")).Times(1)
+
+			_, err := testRelease.GetArchitecture()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("IsStableRelease", func() {
 		It("should return true for stable release version", func() {
 			applianceConfig.Config.OcpRelease.URL = swag.String("quay.io/openshift-release-dev/ocp-release:4.22.0-x86_64")
 			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
-			jsonOutput := `{"metadata":{"version":"4.22.0"}}`
+			jsonOutput := `{"config":{"architecture":"x86_64"},"metadata":{"version":"4.22.0"}}`
 			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
 
 			isStable, err := testRelease.IsStableRelease()
@@ -243,10 +275,10 @@ var _ = Describe("Test Release", func() {
 			Expect(isStable).To(BeTrue())
 		})
 
-		It("should return true for EC release", func() {
+		It("should return true for EC release 4.22.0-ec.5", func() {
 			applianceConfig.Config.OcpRelease.URL = swag.String("quay.io/openshift-release-dev/ocp-release:4.22.0-ec.5-x86_64")
 			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
-			jsonOutput := `{"metadata":{"version":"4.22.0-ec.5"}}`
+			jsonOutput := `{"config":{"architecture":"x86_64"},"metadata":{"version":"4.22.0-ec.5"}}`
 			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
 
 			isStable, err := testRelease.IsStableRelease()
@@ -257,7 +289,7 @@ var _ = Describe("Test Release", func() {
 		It("should return true for RC release version", func() {
 			applianceConfig.Config.OcpRelease.URL = swag.String("quay.io/openshift-release-dev/ocp-release:4.22.0-rc.0-x86_64")
 			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
-			jsonOutput := `{"metadata":{"version":"4.22.0-rc.0"}}`
+			jsonOutput := `{"config":{"architecture":"x86_64"},"metadata":{"version":"4.22.0-rc.0"}}`
 			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
 
 			isStable, err := testRelease.IsStableRelease()
@@ -268,7 +300,7 @@ var _ = Describe("Test Release", func() {
 		It("should return false for nightly release version", func() {
 			applianceConfig.Config.OcpRelease.URL = swag.String("registry.ci.openshift.org/ocp/release:5.0.0-0.nightly-2026-04-23-082815")
 			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
-			jsonOutput := `{"metadata":{"version":"5.0.0-0.nightly-2026-04-23-082815"}}`
+			jsonOutput := `{"config":{"architecture":"x86_64"},"metadata":{"version":"5.0.0-0.nightly-2026-04-23-082815"}}`
 			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
 
 			isStable, err := testRelease.IsStableRelease()
@@ -276,10 +308,10 @@ var _ = Describe("Test Release", func() {
 			Expect(isStable).To(BeFalse())
 		})
 
-		It("should return false for CI release", func() {
+		It("should return false for CI release 5.0.0-0.ci", func() {
 			applianceConfig.Config.OcpRelease.URL = swag.String("registry.ci.openshift.org/ocp/release:5.0.0-0.ci-2026-04-23-153053")
 			cmd := fmt.Sprintf(templateGetMetadata, swag.StringValue(applianceConfig.Config.OcpRelease.URL))
-			jsonOutput := `{"metadata":{"version":"5.0.0-0.ci-2026-04-23-153053"}}`
+			jsonOutput := `{"config":{"architecture":"x86_64"},"metadata":{"version":"5.0.0-0.ci-2026-04-23-153053"}}`
 			mockExecuter.EXPECT().Execute(cmd).Return(jsonOutput, nil).Times(1)
 
 			isStable, err := testRelease.IsStableRelease()


### PR DESCRIPTION
Manual backport of #706 