### PR TITLE
Enhance the shutdown params.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -651,7 +651,7 @@ cat $APPLIANCE_ASSETS/post.sh
 
 #!/bin/bash
 echo Shutting down the machine...
-shutdown -a
+shutdown -P now
 ```
 
 ```bash


### PR DESCRIPTION
shutdown -P now seems to work better than
shutdown -A to power off the node after
the image was written.