### PR TITLE
Reduce stable release mirror log to debug level

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -252,7 +252,7 @@ func (r *release) mirrorImages(imageSetFile, blockedImages, additionalImages, op
 			cmd += " --ignore-release-signature"
 			logrus.Info("CI/Nightly release found - signature-configmap.yaml will not be generated. Setting --ignore-release-signature")
 		} else {
-			logrus.Info("Stable release found - signature-configmap.yaml will be generated for image signature verification")
+			logrus.Debug("Stable release found - signature-configmap.yaml will be generated for image signature verification")
 		}
 
 		logrus.Debugf("Fetching image from OCP release (%s)", cmd)


### PR DESCRIPTION
The stable release path is the common flow. So an Info message on every mirror run adds noise without actionable signal. Debug should be sufficient for troubleshooting when signature-configmap generation is relevant.