### PR TITLE
OCPBUGS-89645: Download coreos10 ISO for OpenShift 5.x

### DIFF
--- a/pkg/coreos/coreos.go
+++ b/pkg/coreos/coreos.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cavaliercoder/go-cpio"
 	"github.com/cavaliergopher/grab/v3"
+	version "github.com/hashicorp/go-version"
 	"github.com/itchyny/gojq"
 	"github.com/openshift/appliance/pkg/asset/config"
 	"github.com/openshift/appliance/pkg/executer"
@@ -22,6 +23,7 @@ const (
 	templateEmbedIgnition   = "coreos-installer iso ignition embed -f --ignition-file %s %s"
 	machineOsImageName      = "machine-os-images"
 	coreOsFileName          = "coreos/coreos-%s.iso"
+	coreOs10FileName        = "coreos/coreos10-%s.iso"
 	coreOsStream            = "coreos/coreos-stream.json"
 	coreOsDiskImageUrlQuery = ".architectures.x86_64.artifacts.metal.formats[\"raw.gz\"].disk.location"
 
@@ -90,7 +92,15 @@ func (c *coreos) DownloadDiskImage() (string, error) {
 }
 
 func (c *coreos) DownloadISO() (string, error) {
-	fileName := fmt.Sprintf(coreOsFileName, c.ApplianceConfig.GetCpuArchitecture())
+	fileNameFmt := coreOsFileName
+	ocpVer, err := version.NewVersion(c.ApplianceConfig.Config.OcpRelease.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse OCP version")
+	}
+	if ocpVer.Segments()[0] >= 5 {
+		fileNameFmt = coreOs10FileName
+	}
+	fileName := fmt.Sprintf(fileNameFmt, c.ApplianceConfig.GetCpuArchitecture())
 	return c.Release.ExtractFile(machineOsImageName, fileName)
 }
 

--- a/pkg/coreos/coreos_test.go
+++ b/pkg/coreos/coreos_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Test CoreOS", func() {
 					PullSecret: "'{\"auths\":{\"\":{\"auth\":\"dXNlcjpwYXNz\"}}}'",
 					OcpRelease: types.ReleaseImage{
 						CpuArchitecture: swag.String(config.CpuArchitectureX86),
+						Version:         "4.16.0",
 					},
 				},
 			},
@@ -54,6 +55,25 @@ var _ = Describe("Test CoreOS", func() {
 		mockRelease.EXPECT().ExtractFile(machineOsImageName, fmt.Sprintf(coreOsFileName, config.CpuArchitectureX86)).Return("", errors.New("some error")).Times(1)
 		_, err := testCoreOs.DownloadISO()
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("DownloadISO - OCP 5.x uses coreos10 filename", func() {
+		coreOS5 := NewCoreOS(CoreOSConfig{
+			ApplianceConfig: &config.ApplianceConfig{
+				Config: &types.ApplianceConfig{
+					OcpRelease: types.ReleaseImage{
+						CpuArchitecture: swag.String(config.CpuArchitectureX86),
+						Version:         "5.0.0",
+					},
+				},
+			},
+			Release:   mockRelease,
+			Executer:  mockExecuter,
+			EnvConfig: &config.EnvConfig{},
+		})
+		mockRelease.EXPECT().ExtractFile(machineOsImageName, fmt.Sprintf(coreOs10FileName, config.CpuArchitectureX86)).Return("/path/to/file", nil).Times(1)
+		_, err := coreOS5.DownloadISO()
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("FetchCoreOSStream - fail", func() {


### PR DESCRIPTION
When the configured OCP release is version 5.x or later, download coreos10-<arch>.iso instead of coreos-<arch>.iso from the machine-os-images bundle. The 4.x filename is unchanged.

Assisted-by: Claude Code