### PR TITLE
OCPBUGS-85255: Set default grub menu entry

### DIFF
--- a/pkg/templates/scripts/grub/user.cfg.template
+++ b/pkg/templates/scripts/grub/user.cfg.template
@@ -1,3 +1,4 @@
+set default='{{.GrubMenuEntryName}}'
 set timeout={{.GrubTimeout}}
 menuentry '{{.GrubMenuEntryName}}' --class gnu-linux --class gnu --class os {
   search --set=root --label {{.RecoveryPartitionName}}


### PR DESCRIPTION
Since 4/27/2026, the agent compact-ipv4 presubmit tests have been failing as "UEFI Firmware Settings" is the first GRUB menu entry, and since no default was set, GRUB always booted into firmware setup instead of the installer. This change sets the installer as the default Grub entry.