### PR TITLE
OCPBUGS-85255: Ensure that installed image is booted

### DIFF
--- a/pkg/asset/appliance/appliance_diskimage.go
+++ b/pkg/asset/appliance/appliance_diskimage.go
@@ -60,7 +60,8 @@ func (a *ApplianceDiskImage) Generate(dependencies asset.Parents) error {
 		consts.UserCfgTemplateFile,
 		templates.GetUserCfgTemplateData(
 			consts.GrubMenuEntryName,
-			swag.BoolValue(applianceConfig.Config.EnableFips)),
+			swag.BoolValue(applianceConfig.Config.EnableFips),
+			true),
 		envConfig.TempDir); err != nil {
 		return log.StopSpinner(spinner, err)
 	}

--- a/pkg/asset/ignition/install_ignition.go
+++ b/pkg/asset/ignition/install_ignition.go
@@ -185,7 +185,7 @@ func (i *InstallIgnition) addRecoveryGrubConfigFile(tempDir string, enableFips *
 	// Generate user.cfg
 	if err := templates.RenderTemplateFile(
 		consts.UserCfgTemplateFile,
-		templates.GetUserCfgTemplateData(consts.GrubMenuEntryNameRecovery, swag.BoolValue(enableFips)),
+		templates.GetUserCfgTemplateData(consts.GrubMenuEntryNameRecovery, swag.BoolValue(enableFips), false),
 		tempDir); err != nil {
 		return err
 	}

--- a/pkg/templates/data.go
+++ b/pkg/templates/data.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetUserCfgTemplateData(grubMenuEntryName string, enableFips bool) interface{} {
+func GetUserCfgTemplateData(grubMenuEntryName string, enableFips bool, setDefault bool) interface{} {
 	var fipsArg string
 	if enableFips {
 		fipsArg = "fips=1"
@@ -23,11 +23,13 @@ func GetUserCfgTemplateData(grubMenuEntryName string, enableFips bool) interface
 		GrubTimeout                              int
 		GrubMenuEntryName, RecoveryPartitionName string
 		FipsArg                                  string
+		SetDefault                               bool
 	}{
 		GrubTimeout:           consts.GrubTimeout,
 		RecoveryPartitionName: consts.RecoveryPartitionName,
 		GrubMenuEntryName:     grubMenuEntryName,
 		FipsArg:               fipsArg,
+		SetDefault:            setDefault,
 	}
 }
 

--- a/pkg/templates/scripts/grub/user.cfg.template
+++ b/pkg/templates/scripts/grub/user.cfg.template
@@ -1,4 +1,6 @@
+{{- if .SetDefault}}
 set default='{{.GrubMenuEntryName}}'
+{{end -}}
 set timeout={{.GrubTimeout}}
 menuentry '{{.GrubMenuEntryName}}' --class gnu-linux --class gnu --class os {
   search --set=root --label {{.RecoveryPartitionName}}


### PR DESCRIPTION
For the agent installer https://github.com/openshift/appliance/pull/725 properly set the Agent ISO to boot instead of the Grub menu. However, this change needs to be conditional so that the installed image will be booted after the first reboot. Fixing to make it conditional.