### PR TITLE
Refresh RPM lockfile and update Konflux prefetch task digest

### DIFF
--- a/.tekton/appliance-pull-request.yaml
+++ b/.tekton/appliance-pull-request.yaml
@@ -179,7 +179,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:5aa530bb95fa77477dad200e4d5d8312ad8bfafef549957f19aa56f1428672fa
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/appliance-push.yaml
+++ b/.tekton/appliance-push.yaml
@@ -176,7 +176,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:5aa530bb95fa77477dad200e4d5d8312ad8bfafef549957f19aa56f1428672fa
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
         - name: kind
           value: task
         resolver: bundles

--- a/rpm-prefetching/rpms.lock.yaml
+++ b/rpm-prefetching/rpms.lock.yaml
@@ -4,13 +4,13 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aardvark-dns-1.16.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aardvark-dns-1.17.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 894557
-    checksum: sha256:078cb118ebc588377497898f7e781d06bb210aae422c099abf24e077710d00b6
+    size: 913252
+    checksum: sha256:ec358de7bb82149cb264315811a73332779e7a388d80abd6db0c23c3ade5975a
     name: aardvark-dns
-    evr: 2:1.16.0-1.el9
-    sourcerpm: aardvark-dns-1.16.0-1.el9.src.rpm
+    evr: 2:1.17.0-1.el9
+    sourcerpm: aardvark-dns-1.17.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 377278
@@ -32,13 +32,13 @@ arches:
     name: augeas-libs
     evr: 1.14.1-3.el9
     sourcerpm: augeas-1.14.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-11.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-12.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 780258
-    checksum: sha256:3d09948696a715d830047ebaba290ac50de3dc90346c3c61da68e909577ac5bb
+    size: 780201
+    checksum: sha256:7067dec539ac32be505397e957a1a80aa45a9c676a4445ba19318a7f593cfa04
     name: capstone
-    evr: 4.0.2-11.el9_7
-    sourcerpm: capstone-4.0.2-11.el9_7.src.rpm
+    evr: 4.0.2-12.el9_8
+    sourcerpm: capstone-4.0.2-12.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 365931
@@ -46,48 +46,48 @@ arches:
     name: checkpolicy
     evr: 3.6-1.el9
     sourcerpm: checkpolicy-3.6-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-21-208.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-21-209.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 62508
-    checksum: sha256:beb835c39f8085d61aec31f655cc1a42ce76a070509f705cd034e5028ce55857
+    size: 64464
+    checksum: sha256:e4c350756b2ddbb825048ab9a55e15f35a2d872ae995c9570aaa5ff723fa0e07
     name: clevis
-    evr: 21-208.el9
-    sourcerpm: clevis-21-208.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-luks-21-208.el9.x86_64.rpm
+    evr: 21-209.el9
+    sourcerpm: clevis-21-209.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/clevis-luks-21-209.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 40033
-    checksum: sha256:48e5a71a245ef9b0c0045dc48a3d02b6832625b73f961a8208848c1dd9e93ec1
+    size: 42035
+    checksum: sha256:e3c4404a7b9d81648d8198b7351b4bc2d2ff19a2c7c13805f02444d2685fa1d4
     name: clevis-luks
-    evr: 21-208.el9
-    sourcerpm: clevis-21-208.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/conmon-2.1.13-1.el9.x86_64.rpm
+    evr: 21-209.el9
+    sourcerpm: clevis-21-209.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/conmon-2.2.1-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 54488
-    checksum: sha256:48014677e05bf5ed4f280275a85dc1bdcdaed0fd36c3e80518691f3ae5511b4d
+    size: 55683
+    checksum: sha256:49f0a60fcbc1e2957f40baddbb636e169b27ab97bce967f66696be0fec7bafd7
     name: conmon
-    evr: 3:2.1.13-1.el9
-    sourcerpm: conmon-2.1.13-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/container-selinux-2.240.0-3.el9_7.noarch.rpm
+    evr: 3:2.2.1-1.el9
+    sourcerpm: conmon-2.2.1-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/container-selinux-2.245.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 61087
-    checksum: sha256:31fcb6999f1cf55dff4e292bf587c9c5930b87e223b9927e77a07b70a82c0d69
+    size: 67978
+    checksum: sha256:754e79abd94c444b812897383aab1d0fe5474c562a7d0825a62689da6d5d9d3d
     name: container-selinux
-    evr: 4:2.240.0-3.el9_7
-    sourcerpm: container-selinux-2.240.0-3.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/containers-common-1-135.el9_7.x86_64.rpm
+    evr: 4:2.245.0-1.el9
+    sourcerpm: container-selinux-2.245.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/containers-common-5.8-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 156920
-    checksum: sha256:16cb92580716383f26c806fe8e01cad9ec3c370d941f95afaa2657003e1d18df
+    size: 170139
+    checksum: sha256:6db3b80aff7a892ea57ce84c95d0cd62bd70f43b1824009bc9a2ba47bca629d2
     name: containers-common
-    evr: 4:1-135.el9_7
-    sourcerpm: containers-common-1-135.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/coreos-installer-0.24.0-3.el9_6.x86_64.rpm
+    evr: 5:5.8-1.el9
+    sourcerpm: containers-common-5.8-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/coreos-installer-0.26.0-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3492798
-    checksum: sha256:6d452f77019890a3b16321bc9ed74e0dd098ea11ae41b05e21378dca2caaa85c
+    size: 3574009
+    checksum: sha256:f45d213884aed0c00b9cda5139428abf34cf3eb184c19b401ec469d8b64db4ee
     name: coreos-installer
-    evr: 0.24.0-3.el9_6
-    sourcerpm: rust-coreos-installer-0.24.0-3.el9_6.src.rpm
+    evr: 0.26.0-1.el9_8
+    sourcerpm: rust-coreos-installer-0.26.0-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/criu-3.19-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 569988
@@ -102,27 +102,27 @@ arches:
     name: criu-libs
     evr: 3.19-3.el9
     sourcerpm: criu-3.19-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/crun-1.27-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 268352
-    checksum: sha256:61b1d11863da6f3c0854fe7d83e97fb32e76569c64eaa413b6146b22beacf49a
+    size: 268116
+    checksum: sha256:0fc29837716c71995f2e7ffe6d11d937260c0eea9fa07beae3d2671cb7363ebd
     name: crun
-    evr: 1.27-1.el9_7
-    sourcerpm: crun-1.27-1.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/dnsmasq-2.85-18.el9_7.x86_64.rpm
+    evr: 1.27-1.el9_8
+    sourcerpm: crun-1.27-1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/d/dnsmasq-2.85-18.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 341428
-    checksum: sha256:4613fd9976e9ccee6729244309de8bf2db9bfa00368ccd8c2842dc83719c26f7
+    size: 341762
+    checksum: sha256:af25aa339c77890152176a17a981bf85434907267682a299f43da1cbd542e66c
     name: dnsmasq
-    evr: 2.85-18.el9_7
-    sourcerpm: dnsmasq-2.85-18.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/edk2-ovmf-20241117-4.el9_7.3.noarch.rpm
+    evr: 2.85-18.el9_8.1
+    sourcerpm: dnsmasq-2.85-18.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/e/edk2-ovmf-20241117-8.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 6407509
-    checksum: sha256:9875a0c7d7dc7f6622d0b1180b7eae0725638fb319f5be8b3fcc0789adf70ffd
+    size: 6407815
+    checksum: sha256:ae5cdcaaa6f357a63cf9ed9336b08a3a8a51819a4591c83953f419a8ae7e913b
     name: edk2-ovmf
-    evr: 20241117-4.el9_7.3
-    sourcerpm: edk2-20241117-4.el9_7.3.src.rpm
+    evr: 20241117-8.el9
+    sourcerpm: edk2-20241117-8.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fuse-overlayfs-1.16-1.el9_7.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 67299
@@ -270,13 +270,13 @@ arches:
     name: libjose
     evr: 14-1.el9
     sourcerpm: jose-14-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libluksmeta-9-12.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libluksmeta-10-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 28058
-    checksum: sha256:088cacedbce4a2476cf6e527da0dfbc48ffb0a75eebb5566f9dc7df4833e5a62
+    size: 24263
+    checksum: sha256:e7750fe39312d65ed3d122316a4d17b0a8fdc8da0c7a804b095143678f177cbc
     name: libluksmeta
-    evr: 9-12.el9
-    sourcerpm: luksmeta-9-12.el9.src.rpm
+    evr: 10-1.el9
+    sourcerpm: luksmeta-10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 36179
@@ -326,13 +326,13 @@ arches:
     name: libslirp
     evr: 4.4.0-8.el9
     sourcerpm: libslirp-4.4.0-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libsoup-2.72.0-12.el9_7.5.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libsoup-2.72.0-16.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 420847
-    checksum: sha256:77f14bc81e45a61618e836049a968acdd998df82263d9eaa7cd83073267ec02d
+    size: 420846
+    checksum: sha256:51e8ba797e199a99037c8e7773e577ad1d7e5d9ca7a84e4e8b044d0a12527dd3
     name: libsoup
-    evr: 2.72.0-12.el9_7.5
-    sourcerpm: libsoup-2.72.0-12.el9_7.5.src.rpm
+    evr: 2.72.0-16.el9_8.1
+    sourcerpm: libsoup-2.72.0-16.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libtpms-0.9.1-6.20211126git1ff6fe1f43.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 187259
@@ -340,76 +340,76 @@ arches:
     name: libtpms
     evr: 0.9.1-6.20211126git1ff6fe1f43.el9
     sourcerpm: libtpms-0.9.1-6.20211126git1ff6fe1f43.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/liburing-2.5-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/liburing-2.12-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 42739
-    checksum: sha256:cc7894188e8c9cc06335a47150f05ad80cbbf91cbf7c877e5e75683bddf61b53
+    size: 43322
+    checksum: sha256:54e8d74fbffb7ff58d19257f68ccf65cb41212715146a18c83d0756782bd1399
     name: liburing
-    evr: 2.5-1.el9
-    sourcerpm: liburing-2.5-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-client-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 2.12-1.el9
+    sourcerpm: liburing-2.12-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-client-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 470559
-    checksum: sha256:bdf03c4c366ca21cfa52b73368d2067c2efce1831e88a51430ec8f8b54e3e7d8
+    size: 483455
+    checksum: sha256:29e718b98357a03d9df9eaab140ee93878868ec0e1966da17b31b002f488013f
     name: libvirt-client
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-common-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-common-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 152381
-    checksum: sha256:eb3d2cb0b293d2293c3d1e78054ea12f1c103c0c3575447f792823d190a46108
+    size: 169273
+    checksum: sha256:7ed822650b9c53766c6a876afda24f269638167b3ec53d1e095ecdee450ac0ac
     name: libvirt-daemon-common
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-config-network-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-config-network-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 38486
-    checksum: sha256:ac3bc04199ae9e760a259b675b730cb1ab2e71982eea6ab2574fd64698c8f60a
+    size: 40850
+    checksum: sha256:062bae997f9519c58d923a7e98aabac9de44d6c0bac0ae8b5d8d46260db97fb3
     name: libvirt-daemon-config-network
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-network-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-network-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 288019
-    checksum: sha256:1efa6c8c14b39327c8c724fc42a7239f39c448934fff9c02f0541dab788ab8b3
+    size: 291907
+    checksum: sha256:3bef812df78bba91a26a76a47fefe41411f9aadd4c1d0bf1451123ff3ee9ac64
     name: libvirt-daemon-driver-network
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-qemu-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-qemu-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1033914
-    checksum: sha256:12a3b999714285df3d55bdfb634a3c3f322afaa3a4ea236b3e259a1a8804ec24
+    size: 1065266
+    checksum: sha256:2aef903ed8df03b4bf73e082da0f50d9b4b7fe6b69a26b4e2fc218dda2a3528d
     name: libvirt-daemon-driver-qemu
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-secret-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-secret-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 231378
-    checksum: sha256:551d76a97fa0ec2e46f0734e867f66352ab73785e5fdbd41acb185e62cf8a31f
+    size: 234021
+    checksum: sha256:ee27a48ee40c4992c3545d5fa310794496b50cb209a92166a5be064ffc09615e
     name: libvirt-daemon-driver-secret
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-storage-core-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-driver-storage-core-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 288630
-    checksum: sha256:087edec1d43ba003e4850464f3a7994394ea630ebf86a8b848530c8f5065a401
+    size: 291992
+    checksum: sha256:9babdac42cde0f30e12ee6f8f5c58a7821bebe41f8883aa2fa7119a1ff442f74
     name: libvirt-daemon-driver-storage-core
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-log-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-daemon-log-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 78465
-    checksum: sha256:7df7b9aecb8bd642c0f203adac0f49beb4b8cbff8ba345c60a55d9d5598a6b90
+    size: 81209
+    checksum: sha256:f5a6e61202435bbf3ee37fb12dbb8787720d07475be3b843e0e53c99f92bdb10
     name: libvirt-daemon-log
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-libs-10.10.0-15.9.el9_7.x86_64.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libvirt-libs-11.10.0-12.3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 5350707
-    checksum: sha256:006b1628ec7ed4fbda818a7cdd3531078d037bd72a24dec6b95d9313e0d149df
+    size: 5773365
+    checksum: sha256:0b56ff27258d42e29c49a356796a6f462ecd2f245ea0a484fc11d5cc900a9736
     name: libvirt-libs
-    evr: 10.10.0-15.9.el9_7
-    sourcerpm: libvirt-10.10.0-15.9.el9_7.src.rpm
+    evr: 11.10.0-12.3.el9_8
+    sourcerpm: libvirt-11.10.0-12.3.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 93189
@@ -417,20 +417,20 @@ arches:
     name: libxcrypt-compat
     evr: 4.4.18-3.el9
     sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxslt-1.1.34-14.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libxslt-1.1.34-14.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 254259
-    checksum: sha256:d92873a046c78ae6837d8b23deecbfa1d6376b81bf587382e89ed345c1d5bad5
+    size: 254411
+    checksum: sha256:b702d5bdce34b424959427b728e319b17747a5a1249be5f908264c5cfcbddf38
     name: libxslt
-    evr: 1.1.34-14.el9_7.1
-    sourcerpm: libxslt-1.1.34-14.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/luksmeta-9-12.el9.x86_64.rpm
+    evr: 1.1.34-14.el9_8.1
+    sourcerpm: libxslt-1.1.34-14.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/luksmeta-10-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 23634
-    checksum: sha256:3be1ff9059f65c2455f1701c388feebbed719b9b40e6cb23aed734f40c746e23
+    size: 20213
+    checksum: sha256:4682601f414253b62cca7edc4f961125144b9a9817d194b8162638180c87bf53
     name: luksmeta
-    evr: 9-12.el9
-    sourcerpm: luksmeta-9-12.el9.src.rpm
+    evr: 10-1.el9
+    sourcerpm: luksmeta-10-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nbdkit-1.38.5-12.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 5789
@@ -480,20 +480,20 @@ arches:
     name: nbdkit-ssh-plugin
     evr: 1.38.5-12.el9
     sourcerpm: nbdkit-1.38.5-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/netavark-1.16.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/netavark-1.17.2-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 3797524
-    checksum: sha256:4a7853c341092b6e0297d026a14f7f2d13c5f5ec0706dd4dc12c62d5e66f7d91
+    size: 3212162
+    checksum: sha256:1bf196b5daa0aa92bd1408418773d70eadbc15442ec8b7f4b91a7be0b41cf693
     name: netavark
-    evr: 2:1.16.0-1.el9
-    sourcerpm: netavark-1.16.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/osinfo-db-20250606-1.el9.noarch.rpm
+    evr: 2:1.17.2-1.el9
+    sourcerpm: netavark-1.17.2-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/osinfo-db-20250606-2.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 577019
-    checksum: sha256:65f4fa0e2d6487b836c2c68da0b04c3132cd62aac82e350d84f1ea3b85ffeff2
+    size: 584431
+    checksum: sha256:c24a54ec354b8798e661f95cd22e58a7416b62c0b6e3ec5f6ee513144ee5aa16
     name: osinfo-db
-    evr: 20250606-1.el9
-    sourcerpm: osinfo-db-20250606-1.el9.src.rpm
+    evr: 20250606-2.el9_8
+    sourcerpm: osinfo-db-20250606-2.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/o/osinfo-db-tools-1.10.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 79633
@@ -501,20 +501,20 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20250512.g8ec1341-4.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20251210.gd04c480-5.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 265398
-    checksum: sha256:d13f19d2588cc629f3b5bac7e0b55436f196e5a31715c38e69e429c4a67ea83f
+    size: 294836
+    checksum: sha256:ef8db6d7789e52961c86b576ccc20cbe8366db03780710bb89b8a37d4e6bd153
     name: passt
-    evr: 0^20250512.g8ec1341-4.el9_7
-    sourcerpm: passt-0^20250512.g8ec1341-4.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20250512.g8ec1341-4.el9_7.noarch.rpm
+    evr: 0^20251210.gd04c480-5.el9_8
+    sourcerpm: passt-0^20251210.gd04c480-5.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20251210.gd04c480-5.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 26331
-    checksum: sha256:2cf23de34ec2073707f53bb0e2ae38bbf54b43aa5a4a38a710c3b41db3b6685b
+    size: 32460
+    checksum: sha256:1df61fd0e0f92aadd579377a51accf08f2d6db78ad95ae3e7555da231a7502d9
     name: passt-selinux
-    evr: 0^20250512.g8ec1341-4.el9_7
-    sourcerpm: passt-0^20250512.g8ec1341-4.el9_7.src.rpm
+    evr: 0^20251210.gd04c480-5.el9_8
+    sourcerpm: passt-0^20251210.gd04c480-5.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 277483
@@ -522,27 +522,27 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/podman-5.6.0-14.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/podman-5.8.2-3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 16799959
-    checksum: sha256:55f1346f7f76386207f0c07786f1ff4b6f713a6348c5cc343609b4265243fb0a
+    size: 17299731
+    checksum: sha256:cfe0f322a4d20cab6793948b9b1c8b5c0c933799f2eba32d942e014dc97d0aa6
     name: podman
-    evr: 6:5.6.0-14.el9_7
-    sourcerpm: podman-5.6.0-14.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-3.el9.noarch.rpm
+    evr: 6:5.8.2-3.el9_8
+    sourcerpm: podman-5.8.2-3.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 77697
-    checksum: sha256:342fa73cc94923b8ce94c4dc6ecb6f8e489b1ecfc7574ed04b93824e061c1c57
+    size: 84137
+    checksum: sha256:fae42a122e2848cfe99736012348f9c008c4d35e818e72e590e993e58d9858ad
     name: policycoreutils-python-utils
-    evr: 3.6-3.el9
-    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.25-3.el9_7.2.noarch.rpm
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.25-7.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 15984
-    checksum: sha256:fc54f541bf440db47821e9c5055bcff5a624abb795f697148469fac6ed150f19
+    size: 16290
+    checksum: sha256:39bf583a997d1ab3f708e15f3825dafdadd9232ec221afa1406dc2cd89634660
     name: python-unversioned-command
-    evr: 3.9.25-3.el9_7.2
-    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
+    evr: 3.9.25-7.el9_8
+    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 80734
@@ -571,34 +571,34 @@ arches:
     name: python3-libsemanage
     evr: 3.6-5.el9_6
     sourcerpm: libsemanage-3.6-5.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-3.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-policycoreutils-3.6-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2210974
-    checksum: sha256:db891ec3a74ccdd7ab2f9cf0a4436e7df3e6702eb483cd111421f79a334e4aea
+    size: 2219410
+    checksum: sha256:eb5d83e26cee47b23b4b802d98cae521f41d8d0d8451a9e5029cd9b5016dd00b
     name: python3-policycoreutils
-    evr: 3.6-3.el9
-    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-9.1.0-29.el9_7.6.x86_64.rpm
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-10.1.0-17.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2634881
-    checksum: sha256:2892f5b7fb10458c6fe10a5075078c03be3ad1b88aa8b5a971d21d49c4f53fa5
+    size: 2686684
+    checksum: sha256:339317a0becfc28226cd0909ac07790097a994c9793a770e5615d3fc6ccc45f9
     name: qemu-img
-    evr: 17:9.1.0-29.el9_7.6
-    sourcerpm: qemu-kvm-9.1.0-29.el9_7.6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-9.1.0-29.el9_7.6.x86_64.rpm
+    evr: 17:10.1.0-17.el9_8.3
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-10.1.0-17.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 711356
-    checksum: sha256:3bc27c407bc7305e40a8c1e5ec61e98d7646355c648e15744b5e3eded4ab01e0
+    size: 722462
+    checksum: sha256:f9e353fe98605729a807ae67c8eba19dc556046fb2cec38d42ea0fe011c45d0e
     name: qemu-kvm-common
-    evr: 17:9.1.0-29.el9_7.6
-    sourcerpm: qemu-kvm-9.1.0-29.el9_7.6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-9.1.0-29.el9_7.6.x86_64.rpm
+    evr: 17:10.1.0-17.el9_8.3
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-10.1.0-17.el9_8.3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 5175209
-    checksum: sha256:988039a03b8424eb262f70802985094462500dbb946da1070394a62dfe21492c
+    size: 5357678
+    checksum: sha256:cd0a9b80907b11afb120a681a4f71a881e8f3e67fde9456d0f98024a85ba403f
     name: qemu-kvm-core
-    evr: 17:9.1.0-29.el9_7.6
-    sourcerpm: qemu-kvm-9.1.0-29.el9_7.6.src.rpm
+    evr: 17:10.1.0-17.el9_8.3
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-39.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15662
@@ -613,27 +613,27 @@ arches:
     name: scrub
     evr: 2.6.1-4.el9
     sourcerpm: scrub-2.6.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seabios-bin-1.16.3-4.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seabios-bin-1.16.3-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 104354
-    checksum: sha256:f2758eb2e733d130750ad3153d7775e8cc71be8bdf8f0f5e4ee7e40257df6236
+    size: 102223
+    checksum: sha256:1a1376b98203ff04877380132c86a73e53f61ec73e13668264018390a1122165
     name: seabios-bin
-    evr: 1.16.3-4.el9
-    sourcerpm: seabios-1.16.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seavgabios-bin-1.16.3-4.el9.noarch.rpm
+    evr: 1.16.3-5.el9
+    sourcerpm: seabios-1.16.3-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/seavgabios-bin-1.16.3-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 37280
-    checksum: sha256:09622222e1b5ff84d2f0df23d29cc21ed3de37003a9a8fee3492f588027f7fd4
+    size: 35026
+    checksum: sha256:e84029bf0dae69080993cc7baaa7f1fb943a59a5fff747bb60482644a07d9896
     name: seavgabios-bin
-    evr: 1.16.3-4.el9
-    sourcerpm: seabios-1.16.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/skopeo-1.20.0-3.el9_7.x86_64.rpm
+    evr: 1.16.3-5.el9
+    sourcerpm: seabios-1.16.3-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/skopeo-1.22.2-6.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8599922
-    checksum: sha256:500206cfd14841e6fc29461d9847f069c4b2d298b06070854f71836254c22dd8
+    size: 8615114
+    checksum: sha256:954c605d231d1ba23425745b6533f7558fe5b737a50bce95a162eddf5da34008
     name: skopeo
-    evr: 2:1.20.0-3.el9_7
-    sourcerpm: skopeo-1.20.0-3.el9_7.src.rpm
+    evr: 2:1.22.2-6.el9_8
+    sourcerpm: skopeo-1.22.2-6.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 48562
@@ -669,20 +669,20 @@ arches:
     name: swtpm-tools
     evr: 0.8.0-2.el9_4
     sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.16.2-21.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.24.2-3.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 564369
-    checksum: sha256:744c97335bacd9050d4f1727e939459c8e073964562e7f36590313ceb18f930f
+    size: 602255
+    checksum: sha256:7c1646c6416b5e34f94f6b2b234cfb8c799a6ec787cfe627a50a8393cfd28e0c
     name: unbound-libs
-    evr: 1.16.2-21.el9
-    sourcerpm: unbound-1.16.2-21.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.50.4-1.el9_7.x86_64.rpm
+    evr: 1.24.2-3.el9_8.1
+    sourcerpm: unbound-1.24.2-3.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.4-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9043928
-    checksum: sha256:e94671716b9d01f971e5a8a89f49c36e0988e64b797faed8978a57f44eee8197
+    size: 9318311
+    checksum: sha256:b718c5e4fa7cac66ddad020a8df276fdaa985cc6f74b28af8a1add8aef33b446
     name: webkit2gtk3-jsc
-    evr: 2.50.4-1.el9_7
-    sourcerpm: webkit2gtk3-2.50.4-1.el9_7.src.rpm
+    evr: 2.52.4-1.el9_8
+    sourcerpm: webkit2gtk3-2.52.4-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/x/xorriso-1.5.4-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 328802
@@ -711,20 +711,20 @@ arches:
     name: attr
     evr: 2.5.1-3.el9
     sourcerpm: attr-2.5.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-67.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-72.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4813551
-    checksum: sha256:1e7ccdae7390ee9323971fef398e41687eb39ca06242ca1ab673ed8b31e99184
+    size: 4821853
+    checksum: sha256:bda706d43bf47267e31db8ac62fe3206122f97ff035daa6c93ce9cd5063a63ca
     name: binutils
-    evr: 2.35.2-67.el9_7.1
-    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-67.el9_7.1.x86_64.rpm
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-72.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 751923
-    checksum: sha256:9dbb88e0bacb4985c5ae21b002fc2a2b2ad316ad3d8bd18e5f5a79729e92e9ee
+    size: 758393
+    checksum: sha256:4d429d1030d8e1c610ba5aea83f8c63090033f440b2c8f788f0e0acd4a3c51b3
     name: binutils-gold
-    evr: 2.35.2-67.el9_7.1
-    sourcerpm: binutils-2.35.2-67.el9_7.1.src.rpm
+    evr: 2.35.2-72.el9
+    sourcerpm: binutils-2.35.2-72.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/b/bzip2-1.0.8-10.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 61101
@@ -739,34 +739,34 @@ arches:
     name: cpio
     evr: 2.13-16.el9
     sourcerpm: cpio-2.13-16.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-27.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-2.9.6-28.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 100903
-    checksum: sha256:8551b711718596fbfef6622bbf32f785864959af9d06a76da2545ec9f3a126e7
+    size: 102444
+    checksum: sha256:3b415381d4bd307686268ec42f646c7770f6a815de73a40a88aab7a7061b30a9
     name: cracklib
-    evr: 2.9.6-27.el9
-    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-27.el9.x86_64.rpm
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cracklib-dicts-2.9.6-28.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 3821230
-    checksum: sha256:ab4356c86bdc996dc9e55703a7ae936e3e46aec6ebf6d6f008e126ff06e83df2
+    size: 3829431
+    checksum: sha256:61c11d3c23b62016b9939f917bb7f7e03cba324eb4ad35b375387ce9f18e25a1
     name: cracklib-dicts
-    evr: 2.9.6-27.el9
-    sourcerpm: cracklib-2.9.6-27.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.7.2-4.el9.x86_64.rpm
+    evr: 2.9.6-28.el9
+    sourcerpm: cracklib-2.9.6-28.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-2.8.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 337170
-    checksum: sha256:2b647e77e1d9f20d2cec47bd95a4457447fa9bea37d71ced621f98fb00ce27d4
+    size: 366566
+    checksum: sha256:b27154b33e84199d5022be0c7c4b0702de217525705a52abed142a20be59952f
     name: cryptsetup
-    evr: 2.7.2-4.el9
-    sourcerpm: cryptsetup-2.7.2-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.7.2-4.el9.x86_64.rpm
+    evr: 2.8.1-3.el9
+    sourcerpm: cryptsetup-2.8.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cryptsetup-libs-2.8.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 529905
-    checksum: sha256:820cf79373150c0a86d9cd2a8ac3a61d4f932b2e7dbdbc87b301dc4e09619994
+    size: 582998
+    checksum: sha256:cf6aedb89677a193e9f041d4918e21cd61a92df99cad2bc3280d8b89a0c6afbd
     name: cryptsetup-libs
-    evr: 2.7.2-4.el9
-    sourcerpm: cryptsetup-2.7.2-4.el9.src.rpm
+    evr: 2.8.1-3.el9
+    sourcerpm: cryptsetup-2.8.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/cyrus-sasl-gssapi-2.1.27-22.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 25734
@@ -774,13 +774,13 @@ arches:
     name: cyrus-sasl-gssapi
     evr: 2.1.27-22.el9
     sourcerpm: cyrus-sasl-2.1.27-22.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/daxctl-libs-78-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/daxctl-libs-82-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 45763
-    checksum: sha256:064003981145cb7383ec6850f1e85ac18183d3dacd1bc568f0a47ba3105fdb96
+    size: 42202
+    checksum: sha256:a2e34509128b46df145f7f9894d81837ca1739b3a512ed240c48d9035e684f0a
     name: daxctl-libs
-    evr: 78-2.el9
-    sourcerpm: ndctl-78-2.el9.src.rpm
+    evr: 82-1.el9
+    sourcerpm: ndctl-82-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dbus-1.12.20-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 8073
@@ -809,34 +809,34 @@ arches:
     name: dbus-libs
     evr: 1:1.12.20-8.el9
     sourcerpm: dbus-1.12.20-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.206-2.el9_7.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-1.02.207-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 149743
-    checksum: sha256:33402d85b67c6a27f2caf402330bfc176d44d91b833a10c9e14e08c1763124a0
+    size: 150134
+    checksum: sha256:a14679f7d698cdfbdf7af29c9a834f5e282422f17feb3bf3f3eb15e9f1f77ba2
     name: device-mapper
-    evr: 9:1.02.206-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-1.02.206-2.el9_7.2.x86_64.rpm
+    evr: 9:1.02.207-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-1.02.207-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 40306
-    checksum: sha256:2443f96e1dd956c64f774a9585981feb96d266110952287d6f83faf871b0c911
+    size: 40843
+    checksum: sha256:eea1035e0656fd1d744388e64b3e6dbe6b2a75f1d0a814d581c4f42c2b457f3e
     name: device-mapper-event
-    evr: 9:1.02.206-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-libs-1.02.206-2.el9_7.2.x86_64.rpm
+    evr: 9:1.02.207-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-event-libs-1.02.207-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 37589
-    checksum: sha256:cda286ab7eed2fb7ff6159c9605e399f528b75d83a4718b59bd75f0fe2d1c467
+    size: 37963
+    checksum: sha256:a7cab313600e8c5f30c90326c27767cf70a1b058cd6840f909ad44eff9de0b0c
     name: device-mapper-event-libs
-    evr: 9:1.02.206-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.206-2.el9_7.2.x86_64.rpm
+    evr: 9:1.02.207-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-libs-1.02.207-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 189084
-    checksum: sha256:188e4bee4b8ca8f10a52884df19b13c5e4c523484a7b65c9ab91d8aa23344651
+    size: 190068
+    checksum: sha256:046cfc5a70fc29c8f1fb07a698d493f334406f31be56314154ed1936ee2ef136
     name: device-mapper-libs
-    evr: 9:1.02.206-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
+    evr: 9:1.02.207-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/device-mapper-persistent-data-1.1.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1173142
@@ -844,20 +844,20 @@ arches:
     name: device-mapper-persistent-data
     evr: 1.1.0-1.el9
     sourcerpm: device-mapper-persistent-data-1.1.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-client-4.4.2-19.b1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-client-4.4.2-20.b1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 812977
-    checksum: sha256:72823b0e47915484302ade0a5480985e51565968a01e884cb899ebc57d21cc5b
+    size: 813835
+    checksum: sha256:b51ec670f7ac1c5e978dcbe8c663979583edb3df8dcb3f23fed272ce8a4b51e9
     name: dhcp-client
-    evr: 12:4.4.2-19.b1.el9
-    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-common-4.4.2-19.b1.el9.noarch.rpm
+    evr: 12:4.4.2-20.b1.el9
+    sourcerpm: dhcp-4.4.2-20.b1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dhcp-common-4.4.2-20.b1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 133925
-    checksum: sha256:abf06b4ccaafa322bd7d49ca8b239d6852af8f4ba31b8ab3edc1512208767327
+    size: 136637
+    checksum: sha256:00981752f15738430591d2ac2bf9ab396f6ba5e4e1226e32927185404e218dc8
     name: dhcp-common
-    evr: 12:4.4.2-19.b1.el9
-    sourcerpm: dhcp-4.4.2-19.b1.el9.src.rpm
+    evr: 12:4.4.2-20.b1.el9
+    sourcerpm: dhcp-4.4.2-20.b1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/diffutils-3.7-12.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 411559
@@ -865,13 +865,13 @@ arches:
     name: diffutils
     evr: 3.7-12.el9
     sourcerpm: diffutils-3.7-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dmidecode-3.6-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dmidecode-3.6-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 108516
-    checksum: sha256:4b594f260608ed2d7c81097a0af147a1805c30a8698f9ed6363293ac8eabce94
+    size: 105778
+    checksum: sha256:bfbf5b720582c97c43919ca97c822adcdbcadeb5bc4f28820fef101cac5921b5
     name: dmidecode
-    evr: 1:3.6-1.el9
-    sourcerpm: dmidecode-3.6-1.el9.src.rpm
+    evr: 1:3.6-2.el9
+    sourcerpm: dmidecode-3.6-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dnf-4.14.0-31.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 490580
@@ -879,13 +879,13 @@ arches:
     name: dnf
     evr: 4.14.0-31.el9
     sourcerpm: dnf-4.14.0-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dnf-plugins-core-4.3.0-24.el9_7.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dnf-plugins-core-4.3.0-26.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 36733
-    checksum: sha256:a96c74a833f819f9dd152519288d714f5b57a50ff04985ee5a1e9d06cc1b5eac
+    size: 43795
+    checksum: sha256:9e559ed75da897efbb9c9f22c936836aa740edf59063faa6c6d3817f0e055d1c
     name: dnf-plugins-core
-    evr: 4.3.0-24.el9_7
-    sourcerpm: dnf-plugins-core-4.3.0-24.el9_7.src.rpm
+    evr: 4.3.0-26.el9
+    sourcerpm: dnf-plugins-core-4.3.0-26.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dosfstools-4.2-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 163749
@@ -893,13 +893,13 @@ arches:
     name: dosfstools
     evr: 4.2-3.el9
     sourcerpm: dosfstools-4.2-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-104.git20250919.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-115.git20260527.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 485164
-    checksum: sha256:09646358c2c17f2577c6c9348ec37bbc56f2d9ba44897064599c92fa7cc1629e
+    size: 492826
+    checksum: sha256:200398849631d7efbffa099917ffc1d506b04e5164e801fbc60a1cfd6d5dda00
     name: dracut
-    evr: 057-104.git20250919.el9_7
-    sourcerpm: dracut-057-104.git20250919.el9_7.src.rpm
+    evr: 057-115.git20260527.el9_8
+    sourcerpm: dracut-057-115.git20260527.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-1.46.5-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1048130
@@ -914,41 +914,41 @@ arches:
     name: e2fsprogs-libs
     evr: 1.46.5-8.el9
     sourcerpm: e2fsprogs-1.46.5-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.193-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 44629
-    checksum: sha256:595b16ef65e5310e6091af8e9ff9dc378249ab3d739f7b02881b3eb33c9acce6
+    size: 43826
+    checksum: sha256:1635fd1ecaa9492fa925956dfd56d10063ca336619218f124ab45df0a38b41b0
     name: elfutils-debuginfod-client
-    evr: 0.193-1.el9
-    sourcerpm: elfutils-0.193-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.193-1.el9.noarch.rpm
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-default-yama-scope-0.194-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 9949
-    checksum: sha256:8f64d1675627246b912a6b7b71bb4c28c2d1ef09753208253c90253a4a31132f
+    size: 8949
+    checksum: sha256:c473f42c0fec97e2830580110509e4522bc62d9b11761d062499354a0bf58959
     name: elfutils-default-yama-scope
-    evr: 0.193-1.el9
-    sourcerpm: elfutils-0.193-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.193-1.el9.x86_64.rpm
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.194-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 209533
-    checksum: sha256:c37308dadac722a4fc928cb4b919c0c5561c458169f754beb7375eb067012195
+    size: 205864
+    checksum: sha256:00bbe4776149d8ccedcdf19dd6ceb08c3bb42ff41b98d744abe101af0b11a6c5
     name: elfutils-libelf
-    evr: 0.193-1.el9
-    sourcerpm: elfutils-0.193-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.193-1.el9.x86_64.rpm
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.194-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 274462
-    checksum: sha256:a1e6d8396c33dadf7f8f568284e90238e0e1d68a77b2c6c4b2e4ff00ff233e70
+    size: 274670
+    checksum: sha256:ad4f6d425cbc975cead56a2c982e38b0146d00944cbd9b3072d3d1f1271237a5
     name: elfutils-libs
-    evr: 0.193-1.el9
-    sourcerpm: elfutils-0.193-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-5.el9_7.1.x86_64.rpm
+    evr: 0.194-1.el9
+    sourcerpm: elfutils-0.194-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/expat-2.5.0-6.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 120241
-    checksum: sha256:e8ce7bfb8667fc6e4d080f4cae71e175a25cc78b5389a41e3e2e05ffe8edeafe
+    size: 126909
+    checksum: sha256:6a0c98d67b643fe620297e4cd7e990f99a86ed6bc90a8295a952c626ecbb9f62
     name: expat
-    evr: 2.5.0-5.el9_7.1
-    sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+    evr: 2.5.0-6.el9_8.1
+    sourcerpm: expat-2.5.0-6.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/f/file-5.39-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 53222
@@ -1040,13 +1040,13 @@ arches:
     name: gzip
     evr: 1.12-1.el9
     sourcerpm: gzip-1.12-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/h/hwdata-0.348-9.20.el9.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/h/hwdata-0.348-9.22.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1739837
-    checksum: sha256:ef60d49d7af96642a8f8dcb41920fe591d3c7748fd45b367dea73e0e2855e209
+    size: 1773961
+    checksum: sha256:c037e4b4e6168eff309f75b1c3b96359734f887528d0d9bb4a6b0dc8e7bcc0e2
     name: hwdata
-    evr: 0.348-9.20.el9
-    sourcerpm: hwdata-0.348-9.20.el9.src.rpm
+    evr: 0.348-9.22.el9
+    sourcerpm: hwdata-0.348-9.22.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/ima-evm-utils-1.6.2-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 73667
@@ -1068,20 +1068,20 @@ arches:
     name: ipcalc
     evr: 1.0.0-5.el9
     sourcerpm: ipcalc-1.0.0-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-6.14.0-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-6.17.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 855964
-    checksum: sha256:e494cc6c8808abac4ac12457596791179744c3df6aa7a57191ae487762a66c4a
+    size: 894459
+    checksum: sha256:008c615c830a69009a560ce44d9eb5924a793ee89b977856a91f1b7099bad1d5
     name: iproute
-    evr: 6.14.0-2.el9
-    sourcerpm: iproute-6.14.0-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-tc-6.14.0-2.el9.x86_64.rpm
+    evr: 6.17.0-2.el9
+    sourcerpm: iproute-6.17.0-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iproute-tc-6.17.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 455465
-    checksum: sha256:87b864a3198a44c900fb1e6f7fb8a9fc1c4872d31f21f709bcc6188a78e56062
+    size: 471758
+    checksum: sha256:6ecb791ff8030e167b21be39ecc13796d924022a6040263ea25999eda57c2599
     name: iproute-tc
-    evr: 6.14.0-2.el9
-    sourcerpm: iproute-6.14.0-2.el9.src.rpm
+    evr: 6.17.0-2.el9
+    sourcerpm: iproute-6.17.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iptables-libs-1.8.10-11.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 476678
@@ -1110,13 +1110,13 @@ arches:
     name: jansson
     evr: 2.14-1.el9
     sourcerpm: jansson-2.14-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-19.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-19.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 191662
-    checksum: sha256:6b4d82714813d7b4a3200bf2856a3c1493d186e9caa916d7a700ec25e4996462
+    size: 197453
+    checksum: sha256:9793a39a4746a09ba89c3d9ccc70150ac6c878286deee26d7e3aabede4666417
     name: jq
-    evr: 1.6-19.el9
-    sourcerpm: jq-1.6-19.el9.src.rpm
+    evr: 1.6-19.el9_8.2
+    sourcerpm: jq-1.6-19.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kbd-2.4.0-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 428483
@@ -1138,20 +1138,20 @@ arches:
     name: kbd-misc
     evr: 2.4.0-11.el9
     sourcerpm: kbd-2.4.0-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-611.47.1.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-687.17.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 18248729
-    checksum: sha256:e2d82d64c6fddf0fdbf75a0699a59473b0e6b83fa82c39560b8ec1bf6d032c1a
+    size: 18078341
+    checksum: sha256:0ccd9d817f2db0376e60da25783b8703d249416069105a5506af02dae73de759
     name: kernel-core
-    evr: 5.14.0-611.47.1.el9_7
-    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-611.47.1.el9_7.x86_64.rpm
+    evr: 5.14.0-687.17.1.el9_8
+    sourcerpm: kernel-5.14.0-687.17.1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-687.17.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 32643437
-    checksum: sha256:d1f0de4880ccb8a41393ed8b00cb545e8be1847b5127621c42b50cf75d7609db
+    size: 32600641
+    checksum: sha256:f7cbfbe864e34e0b5b5e8268c5fc54fb65f4368c4c55d562c98dd254a52a41a7
     name: kernel-modules-core
-    evr: 5.14.0-611.47.1.el9_7
-    sourcerpm: kernel-5.14.0-611.47.1.el9_7.src.rpm
+    evr: 5.14.0-687.17.1.el9_8
+    sourcerpm: kernel-5.14.0-687.17.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/keyutils-1.6.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 79682
@@ -1173,13 +1173,13 @@ arches:
     name: kmod-libs
     evr: 28-11.el9
     sourcerpm: kmod-28-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kpartx-0.8.7-39.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kpartx-0.8.7-45.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 50175
-    checksum: sha256:b0097b2182cb65dc4d4754241e65d12eac65fd7a8959c4d52a23bbfacbe422fd
+    size: 56718
+    checksum: sha256:e0cf3f185642cd144d9a7cc277af6c5de785550012181339c232fecea33b2c7d
     name: kpartx
-    evr: 0.8.7-39.el9_7.1
-    sourcerpm: device-mapper-multipath-0.8.7-39.el9_7.1.src.rpm
+    evr: 0.8.7-45.el9
+    sourcerpm: device-mapper-multipath-0.8.7-45.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 166025
@@ -1201,13 +1201,13 @@ arches:
     name: libbasicobjects
     evr: 0.1.1-53.el9
     sourcerpm: ding-libs-0.6.1-53.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbpf-1.5.0-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbpf-1.5.0-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 190170
-    checksum: sha256:2343be1ae324535811fb6b952ff0d8c23ba5a326582883055d7ed8f0e71433ca
+    size: 188749
+    checksum: sha256:72673b289f5b720462aca02125411285b259139988be54dff7646d7639f7b26d
     name: libbpf
-    evr: 2:1.5.0-2.el9
-    sourcerpm: libbpf-1.5.0-2.el9.src.rpm
+    evr: 2:1.5.0-3.el9
+    sourcerpm: libbpf-1.5.0-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libbrotli-1.0.9-9.el9_7.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 326278
@@ -1243,20 +1243,20 @@ arches:
     name: libdb
     evr: 5.3.28-57.el9_6
     sourcerpm: libdb-5.3.28-57.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-4.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libeconf-0.4.1-7.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 30371
-    checksum: sha256:f7998382ca1be7836f6af05d42dc03f88799abcb10aa7a761e16f74058598012
+    size: 33179
+    checksum: sha256:a570c5baaedeb1445bc2e4f3930b0a709411bbefbdbf463c3e006cbfc7018894
     name: libeconf
-    evr: 0.4.1-4.el9
-    sourcerpm: libeconf-0.4.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
+    evr: 0.4.1-7.el9_8
+    sourcerpm: libeconf-0.4.1-7.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libedit-3.1-39.20210216cvs.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 109330
-    checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
+    size: 112056
+    checksum: sha256:65a730688dfea27934b75af3acf30150c6d254c89d8b68b63233ae7f8b6c9b94
     name: libedit
-    evr: 3.1-38.20210216cvs.el9
-    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+    evr: 3.1-39.20210216cvs.el9
+    sourcerpm: libedit-3.1-39.20210216cvs.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libev-4.33-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 55816
@@ -1271,20 +1271,20 @@ arches:
     name: libfdisk
     evr: 2.37.4-21.el9_7
     sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-11.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgomp-11.5.0-14.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 263529
-    checksum: sha256:da7aa3b4934ff0ccf24f925b8216654cf9c9881f64075e2fde1da4f560ca5c2f
+    size: 263723
+    checksum: sha256:87b9a7316760374111290e6e4c76ee4d093566f08a7c7c91ad7827c5948afb69
     name: libgomp
-    evr: 11.5.0-11.el9
-    sourcerpm: gcc-11.5.0-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-57.0-2.el9.x86_64.rpm
+    evr: 11.5.0-14.el9
+    sourcerpm: gcc-11.5.0-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-61.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 463544
-    checksum: sha256:d96bbefb46683bd3ddfffd0668898c591f253dfca25e5ac2ddf90f812512e5b7
+    size: 498499
+    checksum: sha256:4789955ff27b0339c2b61ad52d492965e0ad7f02cd44b68370ca82d6aa596b41
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libicu-67.1-10.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 10037375
@@ -1334,13 +1334,13 @@ arches:
     name: libnfnetlink
     evr: 1.0.1-23.el9_5
     sourcerpm: libnfnetlink-1.0.1-23.el9_5.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfsidmap-2.5.4-38.el9_7.3.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnfsidmap-2.5.4-42.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 69983
-    checksum: sha256:f035af36b12e56fae25b455c4e8a79464ff67ca43d64623a93a1a81df4693b54
+    size: 69628
+    checksum: sha256:050b6e1cfeff41bd0f6dd81bb81af9e4847f780ef5f4cd60c738dc040b28c8e1
     name: libnfsidmap
-    evr: 1:2.5.4-38.el9_7.3
-    sourcerpm: nfs-utils-2.5.4-38.el9_7.3.src.rpm
+    evr: 1:2.5.4-42.el9_8
+    sourcerpm: nfs-utils-2.5.4-42.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnftnl-1.2.6-4.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 91380
@@ -1355,13 +1355,13 @@ arches:
     name: libnl3
     evr: 3.11.0-1.el9
     sourcerpm: libnl3-3.11.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnvme-1.13-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnvme-1.16.1-3.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 113489
-    checksum: sha256:a950621aa574c884c571cd36406e1fb8ef59cddc5510e65ce820a9d3a3db4588
+    size: 125549
+    checksum: sha256:8c8c2e86a1eb6a5efca1aa858b6b4d3831112d09bdbec9c0b6c3ce0a4488fd46
     name: libnvme
-    evr: 1.13-1.el9
-    sourcerpm: libnvme-1.13-1.el9.src.rpm
+    evr: 1.16.1-3.el9_8
+    sourcerpm: libnvme-1.16.1-3.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpath_utils-0.2.1-53.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 32479
@@ -1376,13 +1376,13 @@ arches:
     name: libpipeline
     evr: 1.5.3-4.el9
     sourcerpm: libpipeline-1.5.3-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpng-1.6.37-12.el9_7.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpng-1.6.37-15.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 124468
-    checksum: sha256:19b5cf6b3a14137a159ea956c61559fb776a72d251b6c60a4d4959cdd88db3d1
+    size: 125091
+    checksum: sha256:bc8c773c49adc1eb21b434a1ae723580ad887cd794237162338fba7963d0eeda
     name: libpng
-    evr: 2:1.6.37-12.el9_7.2
-    sourcerpm: libpng-1.6.37-12.el9_7.2.src.rpm
+    evr: 2:1.6.37-15.el9_8.2
+    sourcerpm: libpng-1.6.37-15.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libproxy-0.4.15-35.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 79470
@@ -1404,13 +1404,13 @@ arches:
     name: libpwquality
     evr: 1.4.4-8.el9
     sourcerpm: libpwquality-1.4.4-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/librdmacm-57.0-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/librdmacm-61.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 71393
-    checksum: sha256:fec607f80cd4964f8146d13bb9e04387b69e3535ef1dd71f37848d2cb83a489b
+    size: 80794
+    checksum: sha256:ec6ce0d92c2f07a1705bcbec567223f860c9f3ddf0ae69048d4202b703448df0
     name: librdmacm
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libref_array-0.1.5-53.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 30902
@@ -1439,20 +1439,20 @@ arches:
     name: libss
     evr: 1.46.5-8.el9
     sourcerpm: e2fsprogs-1.46.5-8.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-17.el9_7.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-0.10.4-18.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 218882
-    checksum: sha256:470f7067968489f9ec3df43266032241563d3cfa577ce2a5b7375a0660833005
+    size: 225119
+    checksum: sha256:4a3ec8a0cc0d4f693a876c522d3e4bc2296180b9ec05f958f6a0aa8658702458
     name: libssh
-    evr: 0.10.4-17.el9_7
-    sourcerpm: libssh-0.10.4-17.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-17.el9_7.noarch.rpm
+    evr: 0.10.4-18.el9
+    sourcerpm: libssh-0.10.4-18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libssh-config-0.10.4-18.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8268
-    checksum: sha256:9815db066478c3b1bdd5367de09e0aedf465127716358a8877990736589c6078
+    size: 14685
+    checksum: sha256:ab353cbff2269677fc7364bfcddb8e11537ea83361a0ad642e60eac87ed67fbb
     name: libssh-config
-    evr: 0.10.4-17.el9_7
-    sourcerpm: libssh-0.10.4-17.el9_7.src.rpm
+    evr: 0.10.4-18.el9
+    sourcerpm: libssh-0.10.4-18.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libtirpc-1.3.3-9.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 98934
@@ -1474,20 +1474,20 @@ arches:
     name: libverto-libev
     evr: 0.3.2-3.el9
     sourcerpm: libverto-0.3.2-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20260311-155.4.el9_7.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20260609-161.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 652032518
-    checksum: sha256:69349f6499b42895202c43889efb8bf26a14725f5637138fc8478c094eee9be6
+    size: 665695422
+    checksum: sha256:b904e30f76ac343c55c4b6cfc6c9d04769a4c8a5e3a25ef6c10b9b13335a7f60
     name: linux-firmware
-    evr: 20260311-155.4.el9_7
-    sourcerpm: linux-firmware-20260311-155.4.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20260311-155.4.el9_7.noarch.rpm
+    evr: 20260609-161.el9_8
+    sourcerpm: linux-firmware-20260609-161.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20260609-161.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 139979
-    checksum: sha256:b9d5531c18183f892199b3efae8da07835fba18c040f2a019aefdb58490ff0b2
+    size: 144721
+    checksum: sha256:9832e860b74f2304850169183ea2a3debfaef39264d30408da898535ed928895
     name: linux-firmware-whence
-    evr: 20260311-155.4.el9_7
-    sourcerpm: linux-firmware-20260311-155.4.el9_7.src.rpm
+    evr: 20260609-161.el9_8
+    sourcerpm: linux-firmware-20260609-161.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lsscsi-0.32-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 72326
@@ -1495,20 +1495,20 @@ arches:
     name: lsscsi
     evr: 0.32-6.el9
     sourcerpm: lsscsi-0.32-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-2.03.32-2.el9_7.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-2.03.33-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1641672
-    checksum: sha256:e20058d0df071f9b61f0cf4167a77d4d91eb7af4cea4ed990930771c659c6c07
+    size: 1645311
+    checksum: sha256:4126219b6dc257e56567cdd5e9432672980c915dc1a9c59b343ef15e6ae3918e
     name: lvm2
-    evr: 9:2.03.32-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-libs-2.03.32-2.el9_7.2.x86_64.rpm
+    evr: 9:2.03.33-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lvm2-libs-2.03.33-4.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1057103
-    checksum: sha256:4065a9a1abe5622caff86480afc5a4ee6b1fe08cd820d2f9c04b38ad2646d055
+    size: 1061256
+    checksum: sha256:5d6070b939b69ef9019a6ffc42648fa609c3ff336085604312711526129c9197
     name: lvm2-libs
-    evr: 9:2.03.32-2.el9_7.2
-    sourcerpm: lvm2-2.03.32-2.el9_7.2.src.rpm
+    evr: 9:2.03.33-4.el9_8.1
+    sourcerpm: lvm2-2.03.33-4.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lzo-2.10-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 70686
@@ -1544,27 +1544,27 @@ arches:
     name: mtools
     evr: 4.0.26-5.el9_7
     sourcerpm: mtools-4.0.26-5.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ndctl-libs-78-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/ndctl-libs-82-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 94842
-    checksum: sha256:9e46d827a61e9c7fe36b5bdb35234bfe703a601309634ba1f109bfb1791f13cf
+    size: 90095
+    checksum: sha256:3bdcb125dbe22646e9c6c05d7bde3480f077dc4fa22a579634342137cf3c39c4
     name: ndctl-libs
-    evr: 78-2.el9
-    sourcerpm: ndctl-78-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nfs-utils-2.5.4-38.el9_7.3.x86_64.rpm
+    evr: 82-1.el9
+    sourcerpm: ndctl-82-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nfs-utils-2.5.4-42.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 480420
-    checksum: sha256:e146bea2584bd7a7d20e752127f4cac4b3bbdd457f309a431613647a35f2c1fa
+    size: 480632
+    checksum: sha256:f0ac80e3b31543848038b9b45e92f32207fed13db8bd37c566ba95074fb0420a
     name: nfs-utils
-    evr: 1:2.5.4-38.el9_7.3
-    sourcerpm: nfs-utils-2.5.4-38.el9_7.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nftables-1.0.9-6.el9_7.x86_64.rpm
+    evr: 1:2.5.4-42.el9_8
+    sourcerpm: nfs-utils-2.5.4-42.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/nftables-1.0.9-7.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 437469
-    checksum: sha256:9ef3679a12f899ab4ebd5da31090c6624cfe35812d96f0f4609666aef7786e47
+    size: 437853
+    checksum: sha256:175e5a5110125df894ef6f7cf7cb657cf16a3c5cee2b2847cb6e285d56c79396
     name: nftables
-    evr: 1:1.0.9-6.el9_7
-    sourcerpm: nftables-1.0.9-6.el9_7.src.rpm
+    evr: 1:1.0.9-7.el9_8
+    sourcerpm: nftables-1.0.9-7.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/n/numactl-libs-2.0.19-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 31071
@@ -1593,13 +1593,13 @@ arches:
     name: openssl
     evr: 1:3.5.1-7.el9_7
     sourcerpm: openssl-3.5.1-7.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-26.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pam-1.5.1-28.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 636788
-    checksum: sha256:247027fa7a2236c1fb46756ed372637f85cf85886603a2ad5ba918e4231324bc
+    size: 637912
+    checksum: sha256:15a0a5000af6f57f47c30682f7aacf3959903788e68255132b6a05bb4b713ab1
     name: pam
-    evr: 1.5.1-26.el9_6
-    sourcerpm: pam-1.5.1-26.el9_6.src.rpm
+    evr: 1.5.1-28.el9
+    sourcerpm: pam-1.5.1-28.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/parted-3.5-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 603349
@@ -1614,13 +1614,13 @@ arches:
     name: pigz
     evr: 2.8-1.el9
     sourcerpm: pigz-2.8-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/policycoreutils-3.6-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 244557
-    checksum: sha256:fe02f46c19edea28a94b6b8756c25649631e6776d9c5597fe71c86b801f6ba2b
+    size: 250930
+    checksum: sha256:fffd2206493e48409306c0494f53a549fb5e2944a7f53ad7377ed76a4b28f671
     name: policycoreutils
-    evr: 3.6-3.el9
-    sourcerpm: policycoreutils-3.6-3.el9.src.rpm
+    evr: 3.6-5.el9
+    sourcerpm: policycoreutils-3.6-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/polkit-0.117-14.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 157152
@@ -1670,13 +1670,13 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-3.el9_7.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 33400
-    checksum: sha256:e90bec441c9e7f22c362ef88e8c73dcff9d3e5287c4fcca77f300bcffbfb35a5
+    size: 33674
+    checksum: sha256:6e19476d33bcc02b1c275c7d01131c3a15f3160d1bbc03348c7929aebbb3f686
     name: python3
-    evr: 3.9.25-3.el9_7.2
-    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
+    evr: 3.9.25-7.el9_8
+    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-dateutil-2.9.0.post0-1.el9_7.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 309563
@@ -1698,13 +1698,13 @@ arches:
     name: python3-dnf
     evr: 4.14.0-31.el9
     sourcerpm: dnf-4.14.0-31.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-dnf-plugins-core-4.3.0-24.el9_7.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-dnf-plugins-core-4.3.0-26.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 269566
-    checksum: sha256:7d1a5b4e6918b6fbcad5e208432ad924d0d24dc889c56a26698cce9b1b2a927f
+    size: 276718
+    checksum: sha256:9aa2887a7695852725d8236853c48224ee81a38f3ee6774a7940423762518958
     name: python3-dnf-plugins-core
-    evr: 4.3.0-24.el9_7
-    sourcerpm: dnf-plugins-core-4.3.0-24.el9_7.src.rpm
+    evr: 4.3.0-26.el9
+    sourcerpm: dnf-plugins-core-4.3.0-26.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-gpg-1.15.1-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 291563
@@ -1733,20 +1733,20 @@ arches:
     name: python3-libdnf
     evr: 0.69.0-17.el9_7
     sourcerpm: libdnf-0.69.0-17.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-3.el9_7.2.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8481242
-    checksum: sha256:63977a71bc8bc289bc0cdf9e51f21ecd46a81cfab760002d58266bb739975640
+    size: 8482615
+    checksum: sha256:91a38a134da1fdf79c721099cf733613b676f1c200f63e434319a34e6d8005be
     name: python3-libs
-    evr: 3.9.25-3.el9_7.2
-    sourcerpm: python3.9-3.9.25-3.el9_7.2.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-1.el9.noarch.rpm
+    evr: 3.9.25-7.el9_8
+    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1193706
-    checksum: sha256:75c46aab03898c66ce16be556432b71aed7efcedce02b9263339c14f57b4fdc0
+    size: 1198443
+    checksum: sha256:918041963ad5c3b91276bf1ed3307280673ca8352e2e632bbb3847b33d2bc15a
     name: python3-pip-wheel
-    evr: 21.3.1-1.el9
-    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+    evr: 21.3.1-2.el9_8
+    sourcerpm: python-pip-21.3.1-2.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pyyaml-5.4.1-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 213932
@@ -1838,27 +1838,27 @@ arches:
     name: rpm-sign-libs
     evr: 4.16.1.3-39.el9
     sourcerpm: rpm-4.16.1.3-39.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.65-1.el9_7.1.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-38.1.75-2.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 44151
-    checksum: sha256:2febb9f769974bd968cb9a5a023f4c596bd68777b782e1320c8472bfdf28d20b
+    size: 47589
+    checksum: sha256:781a7861de4d1b08390037fd2bf632df783135a60b39a686f5796036e8b818d6
     name: selinux-policy
-    evr: 38.1.65-1.el9_7.1
-    sourcerpm: selinux-policy-38.1.65-1.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.65-1.el9_7.1.noarch.rpm
+    evr: 38.1.75-2.el9_8
+    sourcerpm: selinux-policy-38.1.75-2.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/selinux-policy-targeted-38.1.75-2.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 7269373
-    checksum: sha256:d2374ed366fd3ef8618cc222ff141ecbf33033607c66ccccc593197a4e742a5c
+    size: 7272627
+    checksum: sha256:a63a13d5b5883748b2731eb327417feb3c6e32a6c56b8cdb534218e5857a9e30
     name: selinux-policy-targeted
-    evr: 38.1.65-1.el9_7.1
-    sourcerpm: selinux-policy-38.1.65-1.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-15.el9.x86_64.rpm
+    evr: 38.1.75-2.el9_8
+    sourcerpm: selinux-policy-38.1.75-2.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/shadow-utils-subid-4.9-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 86604
-    checksum: sha256:dd1fb90430220033adbd4c52c5c1d53323acc011245b73aafefbc9fa33f40a2b
+    size: 86705
+    checksum: sha256:7ec945faa9fb963f46c863e8f32dd9192e60b548e126296b832b3ecd75f47b47
     name: shadow-utils-subid
-    evr: 2:4.9-15.el9
-    sourcerpm: shadow-utils-4.9-15.el9.src.rpm
+    evr: 2:4.9-16.el9
+    sourcerpm: shadow-utils-4.9-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/snappy-1.1.8-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38032
@@ -1873,83 +1873,83 @@ arches:
     name: squashfs-tools
     evr: 4.4-10.git1.el9
     sourcerpm: squashfs-tools-4.4-10.git1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-6.04-0.20.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-6.04-0.23.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 588436
-    checksum: sha256:9af2b296b7080e7b0551a8fa971e7ee5a3bf709443b43dd5ffd6c9e6d3f8aab0
+    size: 583459
+    checksum: sha256:865751fc596c629e81d3777108b7825b7f5604998fa2ac874b9504449370682a
     name: syslinux
-    evr: 6.04-0.20.el9
-    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-6.04-0.20.el9.x86_64.rpm
+    evr: 6.04-0.23.el9
+    sourcerpm: syslinux-6.04-0.23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-6.04-0.23.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 135023
-    checksum: sha256:7eb3714428f764f644f1995c05a3dbc55077d8fd0b330ba1698e342b1640a63d
+    size: 132453
+    checksum: sha256:ee0c873084cb1435a5ee011c31e2e68bd5fff17caee96a9057154648d19ec551
     name: syslinux-extlinux
-    evr: 6.04-0.20.el9
-    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    evr: 6.04-0.23.el9
+    sourcerpm: syslinux-6.04-0.23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-extlinux-nonlinux-6.04-0.23.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 408744
-    checksum: sha256:a40ce10dd82ee4517f1c528a9ca14f1baa5a2d8b39f298531916688241906460
+    size: 403178
+    checksum: sha256:3b06569912e15c03972e90e8313c1860cf2b74b8147b28695ac99f8c34f64712
     name: syslinux-extlinux-nonlinux
-    evr: 6.04-0.20.el9
-    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-nonlinux-6.04-0.20.el9.noarch.rpm
+    evr: 6.04-0.23.el9
+    sourcerpm: syslinux-6.04-0.23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/syslinux-nonlinux-6.04-0.23.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 591736
-    checksum: sha256:e9b444304de40694390b37c36ace8b0d8ba39f376b9215c3c7977dd2c198e6c1
+    size: 610784
+    checksum: sha256:3b0619f8352f1c8b35ce4e28bf907a7416d6bb2ba611d7ffa64a739c8ae19f9e
     name: syslinux-nonlinux
-    evr: 6.04-0.20.el9
-    sourcerpm: syslinux-6.04-0.20.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-252-55.el9_7.8.x86_64.rpm
+    evr: 6.04-0.23.el9
+    sourcerpm: syslinux-6.04-0.23.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-252-55.el9_7.9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 4394529
-    checksum: sha256:02536e2255182db5ec2a8cc07fdda20062378247699b7bed5e0b0ea72b1ca783
+    size: 4396633
+    checksum: sha256:cda660e51919a1fabc7f59badc12eaf66050e205970f89de8e0b495740292bb2
     name: systemd
-    evr: 252-55.el9_7.8
-    sourcerpm: systemd-252-55.el9_7.8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-55.el9_7.8.x86_64.rpm
+    evr: 252-55.el9_7.9
+    sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-container-252-55.el9_7.9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 588584
-    checksum: sha256:7e8328df6d6177009288cf2b24733aa52a8f2f60b9a3052eb19244608ffc06f0
+    size: 587029
+    checksum: sha256:99afd8984a550c85cc7a75c94f00bff43854bb2a859d9e3a2f9c111a0b92678a
     name: systemd-container
-    evr: 252-55.el9_7.8
-    sourcerpm: systemd-252-55.el9_7.8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.8.x86_64.rpm
+    evr: 252-55.el9_7.9
+    sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-pam-252-55.el9_7.9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 274195
-    checksum: sha256:3cb33a319f67824d3beb8b2f2356995695b4c3ac77ae66c8e6c3315ef822d0bc
+    size: 274003
+    checksum: sha256:52daf8ab50d37e8ac8a769ef317f594da85a15661a8bf8aae8994574cece4c36
     name: systemd-pam
-    evr: 252-55.el9_7.8
-    sourcerpm: systemd-252-55.el9_7.8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.8.noarch.rpm
+    evr: 252-55.el9_7.9
+    sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-rpm-macros-252-55.el9_7.9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 57061
-    checksum: sha256:807a9519d7a3f6b2168ca47666b43e1630b3fa82256e919633a07baa5906b1b2
+    size: 55804
+    checksum: sha256:5947436f19719e51830f02d8a0b419df64a6cba03ecf59127f17c15517cb54b7
     name: systemd-rpm-macros
-    evr: 252-55.el9_7.8
-    sourcerpm: systemd-252-55.el9_7.8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-55.el9_7.8.x86_64.rpm
+    evr: 252-55.el9_7.9
+    sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/s/systemd-udev-252-55.el9_7.9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2120702
-    checksum: sha256:5cfe3d2fd531fe5027951298d978b12ca51fc910354abfcc534f80a303235713
+    size: 2120626
+    checksum: sha256:802a48b683c2531b50e996f43f8fe3ad0826832ebaa9a6ca6142353bdd687aa7
     name: systemd-udev
-    evr: 252-55.el9_7.8
-    sourcerpm: systemd-252-55.el9_7.8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
+    evr: 252-55.el9_7.9
+    sourcerpm: systemd-252-55.el9_7.9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 906521
-    checksum: sha256:4c0beb933074a5254c297e8968b3f41ec5a02b23056997ddcf526fe7e6166482
+    size: 913256
+    checksum: sha256:58b622ab7bc225731a2473e677f16c9eb51b1ed218a86a7aa039a6fed665f245
     name: tar
-    evr: 2:1.34-9.el9_7
-    sourcerpm: tar-1.34-9.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tools-5.2-6.el9.x86_64.rpm
+    evr: 2:1.34-11.el9
+    sourcerpm: tar-1.34-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tools-5.2-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 822146
-    checksum: sha256:c333eb735ed830141a6b1e2a47855913ca5555e9cf06966d03531ad0b67b7e54
+    size: 822994
+    checksum: sha256:aa105049867f416ed2ad833c28e273d536c4e51b4c2bf6e8221d4be93e03eb1e
     name: tpm2-tools
-    evr: 5.2-6.el9
-    sourcerpm: tpm2-tools-5.2-6.el9.src.rpm
+    evr: 5.2-7.el9
+    sourcerpm: tpm2-tools-5.2-7.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tpm2-tss-3.2.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 621714
@@ -1978,13 +1978,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9_7
     sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/v/vim-minimal-8.2.2637-23.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/v/vim-minimal-8.2.2637-26.el9_8.6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 692680
-    checksum: sha256:15277e31ef3134c11d789a5ee07d7cced1a50a5ec3bed96803e114e7c6692a2b
+    size: 695231
+    checksum: sha256:4d6e92aa7dc808fb646848b02488ab48d91ec05d98ac476fb33adcd4a655215b
     name: vim-minimal
-    evr: 2:8.2.2637-23.el9_7.1
-    sourcerpm: vim-8.2.2637-23.el9_7.1.src.rpm
+    evr: 2:8.2.2637-26.el9_8.6
+    sourcerpm: vim-8.2.2637-26.el9_8.6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/w/which-2.21-30.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42038
@@ -2006,13 +2006,13 @@ arches:
     name: xz
     evr: 5.2.5-8.el9_0
     sourcerpm: xz-5.2.5-8.el9_0.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/y/yum-utils-4.3.0-24.el9_7.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/y/yum-utils-4.3.0-26.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 39772
-    checksum: sha256:dfa16deca4b0c9b7827aa878892388310d65a341d4b230010e20990516770660
+    size: 46868
+    checksum: sha256:6464ac3633842ca3fd1736504a6e540248c63c837fcbbc1721aeb6b7ef11ab77
     name: yum-utils
-    evr: 4.3.0-24.el9_7
-    sourcerpm: dnf-plugins-core-4.3.0-24.el9_7.src.rpm
+    evr: 4.3.0-26.el9
+    sourcerpm: dnf-plugins-core-4.3.0-26.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/z/zstd-1.5.5-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 479423


### PR DESCRIPTION
## Summary
- Regenerate `rpm-prefetching/rpms.lock.yaml` with current RHEL 9 AppStream/BaseOS package versions, URLs, and checksums for hermetic Konflux builds.
- Upgrade `task-prefetch-dependencies-oci-ta` to trusted digest `sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975` in pull-request and push pipelines.

## Test plan
- [ ] Konflux PR pipeline completes prefetch-dependencies step without untrusted task errors
- [ ] Hermetic build succeeds through `microdnf install` step