### PR TITLE
NO-ISSUE: Turn on more debugging for oc-mirror

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -43,7 +43,7 @@ const (
 	templateExtractCmd   = "oc adm release extract --command=%s --to=%s %s"
 	templateImageExtract = "oc image extract --path %s:%s --confirm %s"
 	templateGetMetadata  = "oc adm release info %s -o json"
-	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5"
+	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5 --log-level=debug"
 	// ocMirrorDryRun is the command template for running oc mirror in dry-run mode to generate mapping.txt
 	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --dry-run"
 )
@@ -208,6 +208,7 @@ func (r *release) execute(command string) (string, error) {
 	if err == nil {
 		return strings.TrimSpace(stdout), nil
 	}
+	logrus.Debugf("command execution attempt failed: %s", err.Error())
 	return "", err
 }
 
@@ -256,10 +257,11 @@ func (r *release) mirrorImages(imageSetFile, blockedImages, additionalImages, op
 		}
 
 		logrus.Debugf("Fetching image from OCP release (%s)", cmd)
-		_, err = retry.Do(OcMirrorRetries, OcMirrorRetryDelay, r.execute, cmd)
+		results, err := retry.Do(OcMirrorRetries, OcMirrorRetryDelay, r.execute, cmd)
 		if err != nil {
-			return err
+			return fmt.Errorf("%.wfailed to mirror container images", err)
 		}
+		logrus.Debugf("mirroring result: %s", results[0].(string))
 	} else {
 		logrus.Infof("Using pre-mirrored images from: %s", mirrorPath)
 		tempDir = mirrorPath


### PR DESCRIPTION
Increase the log-level for oc-mirror to debug, and log the output at
debug level on each attempt we make to run it, instead of just the first
one and only if all attempts fail.

This is more consistent with the code before [retries were added](https://github.com/openshift/appliance/pull/727), where
the output of oc-mirror was logged unconditionally at debug level.