### PR TITLE
OCPBUGS-90135: Add more oc-mirror retries

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -31,9 +31,9 @@ const (
 	// OcDefaultRetryDelay is the time between retries
 	OcDefaultRetryDelay = time.Second * 5
 	// OcMirrorRetries is the number of times to retry the oc mirror command
-	OcMirrorRetries = 3
+	OcMirrorRetries = 5
 	// OcMirrorRetryDelay is the time between oc mirror retries
-	OcMirrorRetryDelay = time.Second * 30
+	OcMirrorRetryDelay = time.Second * 5
 	// QueryPattern formats the image names for a given release
 	QueryPattern = ".references.spec.tags[] | .name + \" \" + .from.name"
 )
@@ -43,7 +43,7 @@ const (
 	templateExtractCmd   = "oc adm release extract --command=%s --to=%s %s"
 	templateImageExtract = "oc image extract --path %s:%s --confirm %s"
 	templateGetMetadata  = "oc adm release info %s -o json"
-	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=3 --parallel-layers=4 --retry-times=5"
+	ocMirror             = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --parallel-images=4 --parallel-layers=4 --retry-times=5"
 	// ocMirrorDryRun is the command template for running oc mirror in dry-run mode to generate mapping.txt
 	ocMirrorDryRun = "oc mirror --v2 --config=%s docker://127.0.0.1:%d --workspace=file://%s --src-tls-verify=false --dest-tls-verify=false --dry-run"
 )


### PR DESCRIPTION
Because oc-mirror currently fails if there is a single dropped connection while copying any image, we have to run it multiple times. 3 is not proving enough to reliably get all of the images mirrored. Increase to 5. Restore the number of parallel images to 4, since that is likely not having any effect other than slowing down the whole process.