### PR TITLE
chore: update Tekton tasks to trusted versions

### DIFF
--- a/.tekton/appliance-pull-request.yaml
+++ b/.tekton/appliance-pull-request.yaml
@@ -291,7 +291,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/appliance-pull-request.yaml
+++ b/.tekton/appliance-pull-request.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:171eca520b545a0c860c6d59249796ffe5db5be1dab87f3a328fc5ef1fd68af2
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:53a02326bfb930ca5ef6bfa7a33acca833d57752f34f3cb79255fe2e25e7d217
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/appliance-push.yaml
+++ b/.tekton/appliance-push.yaml
@@ -357,7 +357,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:171eca520b545a0c860c6d59249796ffe5db5be1dab87f3a328fc5ef1fd68af2
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:53a02326bfb930ca5ef6bfa7a33acca833d57752f34f3cb79255fe2e25e7d217
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/appliance-push.yaml
+++ b/.tekton/appliance-push.yaml
@@ -288,7 +288,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Updated \`deprecated-image-check\` task SHA256 digest to the trusted version (\`e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e\`)
- Updated \`clamav-scan\` task SHA256 digest to the trusted version (\`53a02326bfb930ca5ef6bfa7a33acca833d57752f34f3cb79255fe2e25e7d217\`)
- Fixed in both \`.tekton/appliance-pull-request.yaml\` and \`.tekton/appliance-push.yaml\`
- Resolves build chain security warnings about untrusted task versions

## Test plan
- [x] Verify Tekton pipeline files are valid YAML
- [ ] Confirm Konflux builds pass with updated task digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)