### PR TITLE
Update oc-mirror locations to CGW following openshift release decoupling

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -30,8 +30,8 @@ ENV LIBGUESTFS_BACKEND=direct
 RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.1/openshift-client-linux.tar.gz || true
 RUN tar xvzf /tmp/openshift-client-linux.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc
 
-# Download oc-mirror
-RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.22.1/oc-mirror.tar.gz || true
+# Download oc-mirror from CGW (Content Gateway)
+RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/cgw/oc-mirror/oc-mirror.tar.gz || true
 RUN tar xvzf /tmp/oc-mirror.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
 
 # Copy openshift-appliance binary

--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -31,7 +31,7 @@ RUN curl -sL -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/
 RUN tar xvzf /tmp/openshift-client-linux.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc
 
 # Download oc-mirror from CGW (Content Gateway)
-RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/cgw/oc-mirror/oc-mirror.tar.gz || true
+RUN curl -sL -o /tmp/oc-mirror.tar.gz https://mirror.openshift.com/pub/cgw/oc-mirror/latest/oc-mirror-rhel9-linux-amd64.tar.gz || true
 RUN tar xvzf /tmp/oc-mirror.tar.gz -C /usr/local/bin && chmod +x /usr/local/bin/oc-mirror
 
 # Copy openshift-appliance binary


### PR DESCRIPTION
Changes the oc-mirror download mirror location to the new content gateway (CGW) location following the decoupling of oc-mirror from the openshift release process in version 5.0+.

See:
- https://redhat.atlassian.net/browse/CLID-525
- https://redhat.atlassian.net/browse/ART-20686