### PR TITLE
[release-4.22] AGENT-1547: Backport NoRegistryClusterInstall feature to release-4.22

### DIFF
--- a/pkg/asset/ignition/interactiveflow_ignition.go
+++ b/pkg/asset/ignition/interactiveflow_ignition.go
@@ -47,7 +47,7 @@ func (i *interactiveFlowIgnition) appendInternalReleaseImageManifest(ign *igntyp
 
 	ocpBundleStr := releasebundle.Tag(versionForTag)
 
-	iriContent := fmt.Sprintf(`apiVersion: machineconfiguration.openshift.io/v1alpha1
+	iriContent := fmt.Sprintf(`apiVersion: machineconfiguration.openshift.io/v1
 kind: InternalReleaseImage
 metadata:
   name: cluster


### PR DESCRIPTION
This patch is part of the NoRegistryClusterInstall feature backport to 4.22. It contains the following PR: 
#719 