### PR TITLE
Refresh RPM prefetch lock for RHEL 9

### DIFF
--- a/rpm-prefetching/rpms.lock.yaml
+++ b/rpm-prefetching/rpms.lock.yaml
@@ -4,13 +4,13 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aardvark-dns-1.17.0-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aardvark-dns-1.17.1-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 913252
-    checksum: sha256:ec358de7bb82149cb264315811a73332779e7a388d80abd6db0c23c3ade5975a
+    size: 908199
+    checksum: sha256:7018a1f963df1cb81c36b02e46132b1d5894e60da4582988bdd22de8650585bb
     name: aardvark-dns
-    evr: 2:1.17.0-1.el9
-    sourcerpm: aardvark-dns-1.17.0-1.el9.src.rpm
+    evr: 2:1.17.1-1.el9_8
+    sourcerpm: aardvark-dns-1.17.1-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/abattis-cantarell-fonts-0.301-4.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 377278
@@ -32,13 +32,13 @@ arches:
     name: augeas-libs
     evr: 1.14.1-3.el9
     sourcerpm: augeas-1.14.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-12.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/capstone-4.0.2-13.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 780201
-    checksum: sha256:7067dec539ac32be505397e957a1a80aa45a9c676a4445ba19318a7f593cfa04
+    size: 780035
+    checksum: sha256:2096a1fc80b591ef6e0d4f2cf4808b950957d2a030d5779c8ab58ba41cd354ff
     name: capstone
-    evr: 4.0.2-12.el9_8
-    sourcerpm: capstone-4.0.2-12.el9_8.src.rpm
+    evr: 4.0.2-13.el9_8
+    sourcerpm: capstone-4.0.2-13.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/checkpolicy-3.6-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 365931
@@ -60,13 +60,13 @@ arches:
     name: clevis-luks
     evr: 21-209.el9
     sourcerpm: clevis-21-209.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/conmon-2.2.1-1.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/conmon-2.2.1-2.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 55683
-    checksum: sha256:49f0a60fcbc1e2957f40baddbb636e169b27ab97bce967f66696be0fec7bafd7
+    size: 55477
+    checksum: sha256:371ee8477701fb25f6fa0f86265954c8c872490525642267d6c70abe6e11515d
     name: conmon
-    evr: 3:2.2.1-1.el9
-    sourcerpm: conmon-2.2.1-1.el9.src.rpm
+    evr: 3:2.2.1-2.el9_8
+    sourcerpm: conmon-2.2.1-2.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/c/container-selinux-2.245.0-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 67978
@@ -501,20 +501,20 @@ arches:
     name: osinfo-db-tools
     evr: 1.10.0-1.el9
     sourcerpm: osinfo-db-tools-1.10.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20251210.gd04c480-5.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-0^20251210.gd04c480-6.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 294836
-    checksum: sha256:ef8db6d7789e52961c86b576ccc20cbe8366db03780710bb89b8a37d4e6bd153
+    size: 294867
+    checksum: sha256:3eb71e330f94e5eb4cc44ae807cd2fb5955c7af3b76b6904e42dfc9ec89e4024
     name: passt
-    evr: 0^20251210.gd04c480-5.el9_8
-    sourcerpm: passt-0^20251210.gd04c480-5.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20251210.gd04c480-5.el9_8.noarch.rpm
+    evr: 0^20251210.gd04c480-6.el9_8
+    sourcerpm: passt-0^20251210.gd04c480-6.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/passt-selinux-0^20251210.gd04c480-6.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 32460
-    checksum: sha256:1df61fd0e0f92aadd579377a51accf08f2d6db78ad95ae3e7555da231a7502d9
+    size: 32461
+    checksum: sha256:3513042725e7ebe3c2abb61ad023f6c92b0daed90b56cb87907e2cae50eb9704
     name: passt-selinux
-    evr: 0^20251210.gd04c480-5.el9_8
-    sourcerpm: passt-0^20251210.gd04c480-5.el9_8.src.rpm
+    evr: 0^20251210.gd04c480-6.el9_8
+    sourcerpm: passt-0^20251210.gd04c480-6.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/pixman-0.40.0-6.el9_3.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 277483
@@ -522,13 +522,13 @@ arches:
     name: pixman
     evr: 0.40.0-6.el9_3
     sourcerpm: pixman-0.40.0-6.el9_3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/podman-5.8.2-3.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/podman-5.8.2-5.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 17299731
-    checksum: sha256:cfe0f322a4d20cab6793948b9b1c8b5c0c933799f2eba32d942e014dc97d0aa6
+    size: 17322242
+    checksum: sha256:0a822e3dc97b0d4200ba98e868eab2d8532e1e10650412517bd01e4de9596eee
     name: podman
-    evr: 6:5.8.2-3.el9_8
-    sourcerpm: podman-5.8.2-3.el9_8.src.rpm
+    evr: 6:5.8.2-5.el9_8
+    sourcerpm: podman-5.8.2-5.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/policycoreutils-python-utils-3.6-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 84137
@@ -536,13 +536,13 @@ arches:
     name: policycoreutils-python-utils
     evr: 3.6-5.el9
     sourcerpm: policycoreutils-3.6-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.25-7.el9_8.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python-unversioned-command-3.9.25-7.el9_8.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 16290
-    checksum: sha256:39bf583a997d1ab3f708e15f3825dafdadd9232ec221afa1406dc2cd89634660
+    size: 16175
+    checksum: sha256:44bb58535b47dfacdcae7ef92c9f859b78badd22199a31ab576cd3529ef99892
     name: python-unversioned-command
-    evr: 3.9.25-7.el9_8
-    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
+    evr: 3.9.25-7.el9_8.2
+    sourcerpm: python3.9-3.9.25-7.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3-audit-3.1.5-7.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 80734
@@ -578,27 +578,27 @@ arches:
     name: python3-policycoreutils
     evr: 3.6-5.el9
     sourcerpm: policycoreutils-3.6-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-10.1.0-17.el9_8.3.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-img-10.1.0-17.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2686684
-    checksum: sha256:339317a0becfc28226cd0909ac07790097a994c9793a770e5615d3fc6ccc45f9
+    size: 2682565
+    checksum: sha256:7c0583b09a32a2b67df6278000e23422cbaf99b5d9f29846f3736eb35804685b
     name: qemu-img
-    evr: 17:10.1.0-17.el9_8.3
-    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-10.1.0-17.el9_8.3.x86_64.rpm
+    evr: 17:10.1.0-17.el9_8.5
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-common-10.1.0-17.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 722462
-    checksum: sha256:f9e353fe98605729a807ae67c8eba19dc556046fb2cec38d42ea0fe011c45d0e
+    size: 720690
+    checksum: sha256:f401c070f689f2e969944452bf4af2392c3a9d24c6970f13f0b16228c7a2465d
     name: qemu-kvm-common
-    evr: 17:10.1.0-17.el9_8.3
-    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-10.1.0-17.el9_8.3.x86_64.rpm
+    evr: 17:10.1.0-17.el9_8.5
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.5.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/q/qemu-kvm-core-10.1.0-17.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 5357678
-    checksum: sha256:cd0a9b80907b11afb120a681a4f71a881e8f3e67fde9456d0f98024a85ba403f
+    size: 5361239
+    checksum: sha256:17883113e78fbcbee84cca7dd54ee661e96ae3e5c4881f5dc4ad2d87fc4b6f62
     name: qemu-kvm-core
-    evr: 17:10.1.0-17.el9_8.3
-    sourcerpm: qemu-kvm-10.1.0-17.el9_8.3.src.rpm
+    evr: 17:10.1.0-17.el9_8.5
+    sourcerpm: qemu-kvm-10.1.0-17.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/r/rpm-plugin-systemd-inhibit-4.16.1.3-39.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 15662
@@ -627,13 +627,13 @@ arches:
     name: seavgabios-bin
     evr: 1.16.3-5.el9
     sourcerpm: seabios-1.16.3-5.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/skopeo-1.22.2-6.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/skopeo-1.22.2-7.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 8615114
-    checksum: sha256:954c605d231d1ba23425745b6533f7558fe5b737a50bce95a162eddf5da34008
+    size: 8623168
+    checksum: sha256:ec499a7f895bc70eae5e50527dbbe6b1ff621ba0599bc8bbf0a55a4661924bbc
     name: skopeo
-    evr: 2:1.22.2-6.el9_8
-    sourcerpm: skopeo-1.22.2-6.el9_8.src.rpm
+    evr: 2:1.22.2-7.el9_8
+    sourcerpm: skopeo-1.22.2-7.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/s/slirp4netns-1.3.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 48562
@@ -669,20 +669,20 @@ arches:
     name: swtpm-tools
     evr: 0.8.0-2.el9_4
     sourcerpm: swtpm-0.8.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.24.2-3.el9_8.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/u/unbound-libs-1.24.2-3.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 602255
-    checksum: sha256:7c1646c6416b5e34f94f6b2b234cfb8c799a6ec787cfe627a50a8393cfd28e0c
+    size: 602546
+    checksum: sha256:eb8bb393521cbe1a1ddfe7b0401c0f7af6eab33a7f5a54fe94dffd9391131290
     name: unbound-libs
-    evr: 1.24.2-3.el9_8.1
-    sourcerpm: unbound-1.24.2-3.el9_8.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.4-1.el9_8.x86_64.rpm
+    evr: 1.24.2-3.el9_8.2
+    sourcerpm: unbound-1.24.2-3.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/w/webkit2gtk3-jsc-2.52.5-1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 9318311
-    checksum: sha256:b718c5e4fa7cac66ddad020a8df276fdaa985cc6f74b28af8a1add8aef33b446
+    size: 9318959
+    checksum: sha256:e779f2f02b2e363f0ffebd42cb38227ab584ff985ec4ea18297a5e241eec2d89
     name: webkit2gtk3-jsc
-    evr: 2.52.4-1.el9_8
-    sourcerpm: webkit2gtk3-2.52.4-1.el9_8.src.rpm
+    evr: 2.52.5-1.el9_8
+    sourcerpm: webkit2gtk3-2.52.5-1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/x/xorriso-1.5.4-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 328802
@@ -893,13 +893,13 @@ arches:
     name: dosfstools
     evr: 4.2-3.el9
     sourcerpm: dosfstools-4.2-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-115.git20260527.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/d/dracut-057-117.git20260625.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 492826
-    checksum: sha256:200398849631d7efbffa099917ffc1d506b04e5164e801fbc60a1cfd6d5dda00
+    size: 492899
+    checksum: sha256:b550ac7662ae2803bfeda276af6c26a44ca95befabf8e4d33c0410a14e8c9d3d
     name: dracut
-    evr: 057-115.git20260527.el9_8
-    sourcerpm: dracut-057-115.git20260527.el9_8.src.rpm
+    evr: 057-117.git20260625.el9_8
+    sourcerpm: dracut-057-117.git20260625.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-1.46.5-8.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1048130
@@ -1138,20 +1138,20 @@ arches:
     name: kbd-misc
     evr: 2.4.0-11.el9
     sourcerpm: kbd-2.4.0-11.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-687.17.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-core-5.14.0-687.34.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 18078341
-    checksum: sha256:0ccd9d817f2db0376e60da25783b8703d249416069105a5506af02dae73de759
+    size: 18144357
+    checksum: sha256:36ade23eed109d3ff0a8ff4f096e893b1068b937d7283d1324fbaf1ca57437bd
     name: kernel-core
-    evr: 5.14.0-687.17.1.el9_8
-    sourcerpm: kernel-5.14.0-687.17.1.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-687.17.1.el9_8.x86_64.rpm
+    evr: 5.14.0-687.34.1.el9_8
+    sourcerpm: kernel-5.14.0-687.34.1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/kernel-modules-core-5.14.0-687.34.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 32600641
-    checksum: sha256:f7cbfbe864e34e0b5b5e8268c5fc54fb65f4368c4c55d562c98dd254a52a41a7
+    size: 32675137
+    checksum: sha256:41aaa53d38bd0f560098286907012410c8f4f18d545fe921bd9344f50b21249b
     name: kernel-modules-core
-    evr: 5.14.0-687.17.1.el9_8
-    sourcerpm: kernel-5.14.0-687.17.1.el9_8.src.rpm
+    evr: 5.14.0-687.34.1.el9_8
+    sourcerpm: kernel-5.14.0-687.34.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/k/keyutils-1.6.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 79682
@@ -1474,20 +1474,20 @@ arches:
     name: libverto-libev
     evr: 0.3.2-3.el9
     sourcerpm: libverto-0.3.2-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20260609-161.el9_8.noarch.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-20260707-161.1.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 665695422
-    checksum: sha256:b904e30f76ac343c55c4b6cfc6c9d04769a4c8a5e3a25ef6c10b9b13335a7f60
+    size: 682867151
+    checksum: sha256:aea83bd629c16f7cbbd3e2dcaf725796ffe1e196c2398ba74d46a22a82a614bb
     name: linux-firmware
-    evr: 20260609-161.el9_8
-    sourcerpm: linux-firmware-20260609-161.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20260609-161.el9_8.noarch.rpm
+    evr: 20260707-161.1.el9_8
+    sourcerpm: linux-firmware-20260707-161.1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/linux-firmware-whence-20260707-161.1.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 144721
-    checksum: sha256:9832e860b74f2304850169183ea2a3debfaef39264d30408da898535ed928895
+    size: 147937
+    checksum: sha256:47bf77e2a50b86aeafbdda8f983fd7a7d5518bf6da2f15aa40ab9e9223374b88
     name: linux-firmware-whence
-    evr: 20260609-161.el9_8
-    sourcerpm: linux-firmware-20260609-161.el9_8.src.rpm
+    evr: 20260707-161.1.el9_8
+    sourcerpm: linux-firmware-20260707-161.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lsscsi-0.32-6.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 72326
@@ -1670,13 +1670,13 @@ arches:
     name: publicsuffix-list-dafsa
     evr: 20210518-3.el9
     sourcerpm: publicsuffix-list-20210518-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-3.9.25-7.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 33674
-    checksum: sha256:6e19476d33bcc02b1c275c7d01131c3a15f3160d1bbc03348c7929aebbb3f686
+    size: 33578
+    checksum: sha256:2af105e729f864def9dda53ac694e3a0dcaa705dd7f786fb533fc4d979044354
     name: python3
-    evr: 3.9.25-7.el9_8
-    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
+    evr: 3.9.25-7.el9_8.2
+    sourcerpm: python3.9-3.9.25-7.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-dateutil-2.9.0.post0-1.el9_7.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 309563
@@ -1733,13 +1733,13 @@ arches:
     name: python3-libdnf
     evr: 0.69.0-17.el9_7
     sourcerpm: libdnf-0.69.0-17.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.25-7.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 8482615
-    checksum: sha256:91a38a134da1fdf79c721099cf733613b676f1c200f63e434319a34e6d8005be
+    size: 8481614
+    checksum: sha256:8b6bc0577b3af67c2a7d9eb6c85a7afb87a01acae1414d1cc72a544061e559c6
     name: python3-libs
-    evr: 3.9.25-7.el9_8
-    sourcerpm: python3.9-3.9.25-7.el9_8.src.rpm
+    evr: 3.9.25-7.el9_8.2
+    sourcerpm: python3.9-3.9.25-7.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/python3-pip-wheel-21.3.1-2.el9_8.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 1198443
@@ -1978,13 +1978,13 @@ arches:
     name: util-linux-core
     evr: 2.37.4-21.el9_7
     sourcerpm: util-linux-2.37.4-21.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/v/vim-minimal-8.2.2637-26.el9_8.6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/v/vim-minimal-8.2.2637-26.el9_8.13.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 695231
-    checksum: sha256:4d6e92aa7dc808fb646848b02488ab48d91ec05d98ac476fb33adcd4a655215b
+    size: 696394
+    checksum: sha256:e0ce0717738af870181a9f42589ea54e739a31a96e85e7feb8335e48abba56fd
     name: vim-minimal
-    evr: 2:8.2.2637-26.el9_8.6
-    sourcerpm: vim-8.2.2637-26.el9_8.6.src.rpm
+    evr: 2:8.2.2637-26.el9_8.13
+    sourcerpm: vim-8.2.2637-26.el9_8.13.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/w/which-2.21-30.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 42038


### PR DESCRIPTION
Regenerate rpms.lock.yaml with current RHEL 9 AppStream/BaseOS package versions, URLs, and checksums for hermetic Konflux prefetch builds.