### PR TITLE
Fix Hermeto prefetch failure for openshift/installer dependency

### DIFF
--- a/.tekton/appliance-pull-request.yaml
+++ b/.tekton/appliance-pull-request.yaml
@@ -166,6 +166,11 @@ spec:
       params:
       - name: input
         value: $(params.prefetch-input)
+      - name: config-file-content
+        value: |
+          gomod:
+            environment_variables:
+              GOPRIVATE: github.com/openshift/installer
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: ociStorage

--- a/.tekton/appliance-push.yaml
+++ b/.tekton/appliance-push.yaml
@@ -163,6 +163,11 @@ spec:
       params:
       - name: input
         value: $(params.prefetch-input)
+      - name: config-file-content
+        value: |
+          gomod:
+            environment_variables:
+              GOPRIVATE: github.com/openshift/installer
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       - name: ociStorage

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/openshift/assisted-image-service v0.0.0-20260130223312-503834119b3e
 	github.com/openshift/assisted-service/api v0.0.0
 	github.com/openshift/hive/apis v0.0.0-20231220215202-ad99b9e52d27
-	github.com/openshift/installer v0.0.0-20241029183827-aa89bb16f585
+	github.com/openshift/installer v1.4.17-0.20241029183827-aa89bb16f585
 	github.com/openshift/machine-config-operator v0.0.1-0.20201023110058-6c8bd9b2915c
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -301,7 +301,7 @@ require (
 	k8s.io/kubectl v0.30.3 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/cluster-api v1.8.4 // indirect
-	sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1 // indirect
+	sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.2-0.20251023220133-66942942ff92 // indirect
 	sigs.k8s.io/cluster-api-provider-azure v1.15.1-0.20240617212811-a52056dfb88c // indirect
 	sigs.k8s.io/cluster-api-provider-gcp v1.7.1-0.20240724153512-c3b8b533143c // indirect
 	sigs.k8s.io/cluster-api-provider-ibmcloud v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -976,8 +976,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20231220215202-ad99b9e52d27 h1:9C86viyQl7HE9yg7Gctgx803Oq6DbrCUAberyMVcWDE=
 github.com/openshift/hive/apis v0.0.0-20231220215202-ad99b9e52d27/go.mod h1:RRH8lt09SAiPECNdsbh7Gun0lkcRWi1nYKq6tDp5WxQ=
-github.com/openshift/installer v0.0.0-20241029183827-aa89bb16f585 h1:6FMX4yiPlQA9/xyl7xdBFho7eBpH+BFVAmezt7emaFs=
-github.com/openshift/installer v0.0.0-20241029183827-aa89bb16f585/go.mod h1:Lp0dhQn+u778dnONxn3f014mb2H2fvPzs43WI59kwgM=
+github.com/openshift/installer v1.4.17-0.20241029183827-aa89bb16f585 h1:YgBjB76Ucp3qIukSZyfpBh4jYQBmCp/F9AqilzpCTvo=
+github.com/openshift/installer v1.4.17-0.20241029183827-aa89bb16f585/go.mod h1:Lp0dhQn+u778dnONxn3f014mb2H2fvPzs43WI59kwgM=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
 github.com/openshift/library-go v0.0.0-20240207105404-126b47137408 h1:Evg6GEvEuyj9toFX14YenXI6hGRnhLWqYx/rHO7VnQ4=
@@ -1741,8 +1741,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
 sigs.k8s.io/cluster-api v1.8.4 h1:jBKQH1H/HUdUFk8T6qDzIxZJfWw1F5ZP0ZpYQJDmTHs=
 sigs.k8s.io/cluster-api v1.8.4/go.mod h1:pXv5LqLxuIbhGIXykyNKiJh+KrLweSBajVHHitPLyoY=
-sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1 h1:vbZUYEB7OfPlfHk6wis+UrvRLTqv5F4Nrjl2WDJ1kiw=
-sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.1/go.mod h1:1aq1EZbirRW6NC2gYUFCc7cVFwX9PM/vDvoU+2oGPuw=
+sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.2-0.20251023220133-66942942ff92 h1:me2kmDBuAolDLxG/i2BXq4nRzaxAOtugsmQvghHrh9A=
+sigs.k8s.io/cluster-api-provider-aws/v2 v2.6.2-0.20251023220133-66942942ff92/go.mod h1:1aq1EZbirRW6NC2gYUFCc7cVFwX9PM/vDvoU+2oGPuw=
 sigs.k8s.io/cluster-api-provider-azure v1.15.1-0.20240617212811-a52056dfb88c h1:ujrGTddl9yRXaqVPJ81+aBCGUAQtrlmGg+uCRJHE7vU=
 sigs.k8s.io/cluster-api-provider-azure v1.15.1-0.20240617212811-a52056dfb88c/go.mod h1:dqGwr0KL+jdgqnHPTCfCI5TccFtH1MgTnv1vx3wXEak=
 sigs.k8s.io/cluster-api-provider-gcp v1.7.1-0.20240724153512-c3b8b533143c h1:ynsoxyNN9W0iXJzBYflyj6KGFciLRyjwBBin8e/oeSo=


### PR DESCRIPTION
Issue:
Hermeto (prefetch-dependencies) fails with 404 when resolving github.com/openshift/installer@v0.0.0-20241029183827-aa89bb16f585. The go module proxy no longer recognizes this pseudo-version because a tag (v1.4.17) was added to the release-4.16 branch after the dependency was originally pinned, changing the canonical pseudo-version format from v0.0.0-... to v1.4.17-0....

Solution:
Update the pseudo-version to the canonical form
v1.4.17-0.20241029183827-aa89bb16f585. This points to the exact same commit (aa89bb16f585) on the release-4.16 branch, but uses the correct base version that the Go module proxy now expects.