### PR TITLE
MGMT-24998: bump Go to 1.26.3

### DIFF
--- a/Dockerfile.openshift-appliance
+++ b/Dockerfile.openshift-appliance
@@ -1,5 +1,5 @@
 # Build appliance
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/Dockerfile.openshift-appliance.ds
+++ b/Dockerfile.openshift-appliance.ds
@@ -1,5 +1,5 @@
 # Build appliance
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download


### PR DESCRIPTION
Go HTTP/2 Transport enters an infinite loop when receiving SETTINGS_MAX_FRAME_SIZE=0, causing a denial of service. Fixed in Go 1.25.10 and 1.26.3. Since ubi9/go-toolset:1.25.10 is not yet available, bumping to 1.26.3 (Dockerfile uses the floating :1.26 tag, currently resolving to 1.26.5).